### PR TITLE
test: close mutation-testing gaps found by cargo mutants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cargo-crap
-        run: cargo binstall -y cargo-crap --version 0.3.0
+        run: cargo binstall -y --force cargo-crap --version 0.3.0
 
       - name: Generate coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cargo-crap
-        run: cargo binstall -y cargo-crap
+        run: cargo binstall -y cargo-crap --version 0.3.0
 
       - name: Generate coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/crap_baseline.json
+++ b/crap_baseline.json
@@ -5,7 +5,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "CacheStats::hit_rate",
-      "line": 436,
+      "line": 423,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0,
@@ -14,7 +14,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "DistributionCache::cleanup_all_expired",
-      "line": 403,
+      "line": 390,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -23,7 +23,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "DistributionCache::clear_all",
-      "line": 397,
+      "line": 384,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -32,7 +32,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "DistributionCache::default",
-      "line": 422,
+      "line": 409,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -41,15 +41,6 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "DistributionCache::get_or_compute_pdf_kde",
-      "line": 379,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
-      "function": "DistributionCache::get_or_compute_samples",
       "line": 366,
       "cyclomatic": 1.0,
       "coverage": 100.0,
@@ -58,8 +49,17 @@
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
+      "function": "DistributionCache::get_or_compute_samples",
+      "line": 353,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0,
+      "crate": "uncertain-rs"
+    },
+    {
+      "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "DistributionCache::new",
-      "line": 357,
+      "line": 344,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -68,7 +68,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "DistributionCache::overall_stats",
-      "line": 410,
+      "line": 397,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -77,7 +77,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::cleanup_all_expired",
-      "line": 296,
+      "line": 285,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -86,7 +86,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::clear_all",
-      "line": 284,
+      "line": 274,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -95,7 +95,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::default",
-      "line": 343,
+      "line": 330,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -104,7 +104,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_cdf",
-      "line": 252,
+      "line": 242,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -113,7 +113,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_confidence_interval",
-      "line": 236,
+      "line": 226,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -122,7 +122,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_expected_value",
-      "line": 190,
+      "line": 188,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -131,7 +131,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_kurtosis",
-      "line": 228,
+      "line": 218,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -140,7 +140,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_quantile",
-      "line": 268,
+      "line": 258,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -149,16 +149,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_skewness",
-      "line": 220,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
-      "function": "StatisticsCache::get_or_compute_std_dev",
-      "line": 212,
+      "line": 210,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -167,7 +158,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::get_or_compute_variance",
-      "line": 204,
+      "line": 202,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -176,7 +167,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::new",
-      "line": 175,
+      "line": 174,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -185,7 +176,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::overall_stats",
-      "line": 315,
+      "line": 303,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0,
@@ -194,7 +185,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "StatisticsCache::quantize_float",
-      "line": 309,
+      "line": 297,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -259,8 +250,8 @@
       "function": "TtlCache::hit_rate",
       "line": 122,
       "cyclomatic": 2.0,
-      "coverage": 0.0,
-      "crap": 6.0,
+      "coverage": 100.0,
+      "crap": 2.0,
       "crate": "uncertain-rs"
     },
     {
@@ -304,14 +295,14 @@
       "function": "TtlCache::reset_stats",
       "line": 142,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "cleanup_global_caches",
-      "line": 459,
+      "line": 446,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -320,7 +311,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "clear_global_caches",
-      "line": 465,
+      "line": 452,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -329,7 +320,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "dist_cache",
-      "line": 454,
+      "line": 441,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -338,7 +329,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "global_cache_stats",
-      "line": 472,
+      "line": 459,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -347,7 +338,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "print_cache_report",
-      "line": 477,
+      "line": 464,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0,
@@ -356,7 +347,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/cache.rs",
       "function": "stats_cache",
-      "line": 448,
+      "line": 435,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -385,8 +376,8 @@
       "function": "ComputationNode::compute_complexity",
       "line": 390,
       "cyclomatic": 5.0,
-      "coverage": 92.3076923076923,
-      "crap": 5.011379153390988,
+      "coverage": 100.0,
+      "crap": 5.0,
       "crate": "uncertain-rs"
     },
     {
@@ -403,8 +394,8 @@
       "function": "ComputationNode::depth",
       "line": 362,
       "cyclomatic": 5.0,
-      "coverage": 90.0,
-      "crap": 5.025,
+      "coverage": 100.0,
+      "crap": 5.0,
       "crate": "uncertain-rs"
     },
     {
@@ -457,8 +448,8 @@
       "function": "ComputationNode::has_conditionals",
       "line": 377,
       "cyclomatic": 6.0,
-      "coverage": 87.5,
-      "crap": 6.0703125,
+      "coverage": 100.0,
+      "crap": 6.0,
       "crate": "uncertain-rs"
     },
     {
@@ -493,8 +484,8 @@
       "function": "ComputationNode::node_count",
       "line": 345,
       "cyclomatic": 5.0,
-      "coverage": 90.9090909090909,
-      "crap": 5.018782870022539,
+      "coverage": 100.0,
+      "crap": 5.0,
       "crate": "uncertain-rs"
     },
     {
@@ -511,8 +502,8 @@
       "function": "GraphOptimizer::check_addition_identities",
       "line": 685,
       "cyclomatic": 5.0,
-      "coverage": 73.68421052631578,
-      "crap": 5.455605773436361,
+      "coverage": 100.0,
+      "crap": 5.0,
       "crate": "uncertain-rs"
     },
     {
@@ -520,8 +511,8 @@
       "function": "GraphOptimizer::check_division_identities",
       "line": 809,
       "cyclomatic": 3.0,
-      "coverage": 85.71428571428571,
-      "crap": 3.0262390670553936,
+      "coverage": 100.0,
+      "crap": 3.0,
       "crate": "uncertain-rs"
     },
     {
@@ -529,8 +520,8 @@
       "function": "GraphOptimizer::check_multiplication_identities",
       "line": 744,
       "cyclomatic": 9.0,
-      "coverage": 60.0,
-      "crap": 14.184000000000001,
+      "coverage": 100.0,
+      "crap": 9.0,
       "crate": "uncertain-rs"
     },
     {
@@ -538,8 +529,8 @@
       "function": "GraphOptimizer::check_subtraction_identities",
       "line": 721,
       "cyclomatic": 3.0,
-      "coverage": 85.71428571428571,
-      "crap": 3.0262390670553936,
+      "coverage": 100.0,
+      "crap": 3.0,
       "crate": "uncertain-rs"
     },
     {
@@ -673,8 +664,8 @@
       "function": "GraphOptimizer::is_constant",
       "line": 1125,
       "cyclomatic": 3.0,
-      "coverage": 90.0,
-      "crap": 3.009,
+      "coverage": 100.0,
+      "crap": 3.0,
       "crate": "uncertain-rs"
     },
     {
@@ -682,8 +673,8 @@
       "function": "GraphOptimizer::is_constant_bool",
       "line": 1140,
       "cyclomatic": 3.0,
-      "coverage": 87.5,
-      "crap": 3.017578125,
+      "coverage": 100.0,
+      "crap": 3.0,
       "crate": "uncertain-rs"
     },
     {
@@ -691,8 +682,8 @@
       "function": "GraphOptimizer::is_constant_one",
       "line": 909,
       "cyclomatic": 3.0,
-      "coverage": 88.88888888888889,
-      "crap": 3.0123456790123457,
+      "coverage": 100.0,
+      "crap": 3.0,
       "crate": "uncertain-rs"
     },
     {
@@ -799,8 +790,8 @@
       "function": "SampleContext::adaptive_sampling",
       "line": 119,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -862,8 +853,8 @@
       "function": "SampleContext::set_adaptive_sampling",
       "line": 124,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -880,8 +871,8 @@
       "function": "SampleContext::should_cache_node",
       "line": 103,
       "cyclomatic": 5.0,
-      "coverage": 85.71428571428571,
-      "crap": 5.072886297376093,
+      "coverage": 100.0,
+      "crap": 5.0,
       "crate": "uncertain-rs"
     },
     {
@@ -961,8 +952,8 @@
       "function": "Uncertain::gamma_unchecked",
       "line": 392,
       "cyclomatic": 1.0,
-      "coverage": 80.95238095238095,
-      "crap": 1.0069107007882518,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1177,8 +1168,8 @@
       "function": "MultipleHypothesisTester::test_all",
       "line": 325,
       "cyclomatic": 2.0,
-      "coverage": 95.65217391304348,
-      "crap": 2.000328758116216,
+      "coverage": 100.0,
+      "crap": 2.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1186,8 +1177,8 @@
       "function": "Uncertain::bayesian_update",
       "line": 259,
       "cyclomatic": 3.0,
-      "coverage": 88.23529411764706,
-      "crap": 3.0146549969468754,
+      "coverage": 94.11764705882352,
+      "crap": 3.0018318746183597,
       "crate": "uncertain-rs"
     },
     {
@@ -1204,8 +1195,8 @@
       "function": "Uncertain::evaluate_hypothesis",
       "line": 133,
       "cyclomatic": 6.0,
-      "coverage": 87.71929824561403,
-      "crap": 6.0666763862565,
+      "coverage": 100.0,
+      "crap": 6.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1294,8 +1285,8 @@
       "function": "Uncertain::div",
       "line": 241,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1339,8 +1330,8 @@
       "function": "Uncertain::neg",
       "line": 261,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1402,8 +1393,8 @@
       "function": "f32::one",
       "line": 41,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1411,8 +1402,8 @@
       "function": "f32::zero",
       "line": 37,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1429,8 +1420,8 @@
       "function": "f64::div",
       "line": 249,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1438,8 +1429,8 @@
       "function": "f64::mul",
       "line": 213,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1456,8 +1447,8 @@
       "function": "f64::sub",
       "line": 177,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1474,8 +1465,8 @@
       "function": "i32::one",
       "line": 51,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1483,8 +1474,8 @@
       "function": "i32::zero",
       "line": 47,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1492,8 +1483,8 @@
       "function": "i64::one",
       "line": 61,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1501,8 +1492,8 @@
       "function": "i64::zero",
       "line": 57,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1510,8 +1501,8 @@
       "function": "u32::one",
       "line": 71,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1519,8 +1510,8 @@
       "function": "u32::zero",
       "line": 67,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1528,8 +1519,8 @@
       "function": "u64::one",
       "line": 81,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1537,8 +1528,8 @@
       "function": "u64::zero",
       "line": 77,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1555,8 +1546,8 @@
       "function": "Uncertain::eq",
       "line": 96,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1564,8 +1555,8 @@
       "function": "Uncertain::eq_uncertain",
       "line": 140,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1573,8 +1564,8 @@
       "function": "Uncertain::ge",
       "line": 81,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1600,8 +1591,8 @@
       "function": "Uncertain::le",
       "line": 87,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1618,8 +1609,8 @@
       "function": "Uncertain::lt_uncertain",
       "line": 132,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1627,8 +1618,8 @@
       "function": "Uncertain::ne",
       "line": 102,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1753,8 +1744,8 @@
       "function": "Uncertain::xor",
       "line": 96,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -1780,8 +1771,8 @@
       "function": "AdaptiveLazyStats::mean",
       "line": 293,
       "cyclomatic": 7.0,
-      "coverage": 83.33333333333334,
-      "crap": 7.226851851851851,
+      "coverage": 95.83333333333334,
+      "crap": 7.003544560185185,
       "crate": "uncertain-rs"
     },
     {
@@ -1816,8 +1807,8 @@
       "function": "AdaptiveLazyStats::variance",
       "line": 330,
       "cyclomatic": 7.0,
-      "coverage": 83.33333333333334,
-      "crap": 7.226851851851851,
+      "coverage": 95.83333333333334,
+      "crap": 7.003544560185185,
       "crate": "uncertain-rs"
     },
     {
@@ -1861,8 +1852,8 @@
       "function": "LazyStats::quantile",
       "line": 120,
       "cyclomatic": 4.0,
-      "coverage": 85.0,
-      "crap": 4.054,
+      "coverage": 90.0,
+      "crap": 4.016,
       "crate": "uncertain-rs"
     },
     {
@@ -2041,8 +2032,8 @@
       "function": "Uncertain::expected_value_adaptive",
       "line": 631,
       "cyclomatic": 5.0,
-      "coverage": 92.85714285714286,
-      "crap": 5.009110787172012,
+      "coverage": 100.0,
+      "crap": 5.0,
       "crate": "uncertain-rs"
     },
     {
@@ -2257,8 +2248,8 @@
       "function": "Uncertain::id",
       "line": 78,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {
@@ -2365,8 +2356,8 @@
       "function": "Uncertain::take_samples_cached",
       "line": 242,
       "cyclomatic": 1.0,
-      "coverage": 0.0,
-      "crap": 2.0,
+      "coverage": 100.0,
+      "crap": 1.0,
       "crate": "uncertain-rs"
     },
     {

--- a/justfile
+++ b/justfile
@@ -54,14 +54,18 @@ crap-update-baseline:
 dev: fmt-check lint test test-parallel test-doc audit deny crap
 
 # Mutation testing on files changed vs main (re-runs dev first)
+# --all-features is required: without it, mutants behind #[cfg(feature = "parallel")]
+# aren't compiled at all, so cargo-mutants reports them (and their guarding tests) as
+# MISSED regardless of actual test quality -- the mutation is a no-op if the code
+# doesn't exist in the build.
 dev-mutants-diff: dev
     mkdir -p target
     git diff origin/main...HEAD -- '*.rs' > target/mutants-diff.patch
-    cargo mutants --in-diff target/mutants-diff.patch
+    cargo mutants --all-features --in-diff target/mutants-diff.patch
 
 # Full mutation-testing run across the whole crate (slow)
 mutants:
-    cargo mutants
+    cargo mutants --all-features
 
 # Run the criterion benchmark suite
 bench:

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -757,6 +757,136 @@ mod tests {
     }
 
     #[test]
+    fn test_ttl_cache_hit_rate_exact() {
+        // `get_or_compute` gives deterministic counting: the first call on a
+        // fresh key is always a miss, every subsequent call on that same
+        // (non-expired) key is a hit. A bare `.get()` on a key that was never
+        // inserted counts as neither (see `TtlCache::get`), so it can't be
+        // used to manufacture a miss here.
+        let cache = TtlCache::new(Duration::from_secs(10));
+        let _ = cache.get_or_compute("k", || 1); // miss
+        let _ = cache.get_or_compute("k", || 2); // hit
+        let _ = cache.get_or_compute("k", || 3); // hit
+        let _ = cache.get_or_compute("k", || 4); // hit
+
+        assert!((cache.hit_rate() - 75.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_ttl_cache_hit_rate_zero_total() {
+        let cache: TtlCache<&str, i32> = TtlCache::new(Duration::from_secs(10));
+        assert_eq!(cache.hit_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_cache_stats_hit_rate_exact() {
+        let stats = CacheStats { hits: 3, misses: 1 };
+        assert!((stats.hit_rate() - 75.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_cache_stats_hit_rate_zero_total() {
+        let stats = CacheStats { hits: 0, misses: 0 };
+        assert_eq!(stats.hit_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_ttl_cache_reset_stats() {
+        let cache = TtlCache::new(Duration::from_secs(10));
+        let _ = cache.get_or_compute("k", || 1); // miss
+        let _ = cache.get_or_compute("k", || 2); // hit
+
+        let stats = cache.cache_stats();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 1);
+
+        cache.reset_stats();
+
+        let stats_after = cache.cache_stats();
+        assert_eq!(stats_after.hits, 0);
+        assert_eq!(stats_after.misses, 0);
+    }
+
+    #[test]
+    fn test_statistics_cache_cleanup_all_expired_removes_entries() {
+        // Field access relies on this test module being a child of the `cache`
+        // module (private fields are visible to descendant modules).
+        let short_ttl = Duration::from_millis(20);
+        let long_ttl = Duration::from_secs(300);
+        let cache = StatisticsCache {
+            expected_value: TtlCache::new(short_ttl),
+            variance: TtlCache::new(short_ttl),
+            skewness: TtlCache::new(long_ttl),
+            kurtosis: TtlCache::new(long_ttl),
+            confidence_intervals: TtlCache::new(long_ttl),
+            cdf: TtlCache::new(long_ttl),
+            quantiles: TtlCache::new(long_ttl),
+        };
+        let id = uuid::Uuid::new_v4();
+        cache.get_or_compute_expected_value(id, 10, || 1.0);
+        cache.get_or_compute_variance(id, 10, || 2.0);
+        assert_eq!(cache.expected_value.len(), 1);
+        assert_eq!(cache.variance.len(), 1);
+
+        thread::sleep(Duration::from_millis(40));
+        cache.cleanup_all_expired();
+
+        assert_eq!(cache.expected_value.len(), 0);
+        assert_eq!(cache.variance.len(), 0);
+    }
+
+    #[test]
+    fn test_distribution_cache_cleanup_all_expired_removes_entries() {
+        let short_ttl = Duration::from_millis(20);
+        let cache = DistributionCache {
+            samples: TtlCache::new(short_ttl),
+            pdf_kde: TtlCache::new(short_ttl),
+        };
+        let id = uuid::Uuid::new_v4();
+        cache.get_or_compute_samples(id, 10, || vec![1.0]);
+        cache.get_or_compute_pdf_kde(id, 10, 1.0, 0.1, || 0.5);
+        assert_eq!(cache.samples.len(), 1);
+        assert_eq!(cache.pdf_kde.len(), 1);
+
+        thread::sleep(Duration::from_millis(40));
+        cache.cleanup_all_expired();
+
+        assert_eq!(cache.samples.len(), 0);
+        assert_eq!(cache.pdf_kde.len(), 0);
+    }
+
+    #[test]
+    fn test_statistics_cache_overall_stats_exact() {
+        let cache = StatisticsCache::new();
+        let id1 = uuid::Uuid::new_v4();
+        let id2 = uuid::Uuid::new_v4();
+
+        cache.get_or_compute_expected_value(id1, 10, || 1.0); // miss
+        cache.get_or_compute_expected_value(id1, 10, || 2.0); // hit (cached)
+        cache.get_or_compute_variance(id2, 10, || 5.0); // miss
+
+        let stats = cache.overall_stats();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 2);
+    }
+
+    #[test]
+    fn test_distribution_cache_overall_stats_exact() {
+        let cache = DistributionCache::new();
+        let id1 = uuid::Uuid::new_v4();
+        cache.get_or_compute_samples(id1, 10, || vec![1.0]); // miss
+        cache.get_or_compute_samples(id1, 10, || vec![2.0]); // hit (cached)
+
+        let id2 = uuid::Uuid::new_v4();
+        cache.get_or_compute_pdf_kde(id2, 10, 1.0, 0.1, || 0.5); // miss
+        cache.get_or_compute_pdf_kde(id2, 10, 1.0, 0.1, || 0.9); // hit (cached)
+
+        let stats = cache.overall_stats();
+        assert_eq!(stats.hits, 2);
+        assert_eq!(stats.misses, 2);
+    }
+
+    #[test]
     fn test_cache_key_precision_handling() {
         let cache = StatisticsCache::new();
         let test_id = uuid::Uuid::new_v4();

--- a/src/computation.rs
+++ b/src/computation.rs
@@ -2001,4 +2001,285 @@ mod tests {
         let cloned = stats.clone();
         assert_eq!(cloned.count, stats.count);
     }
+
+    #[test]
+    fn test_with_caching_strategy_sets_strategy() {
+        let context = SampleContext::with_caching_strategy(CachingStrategy::Aggressive);
+        let trivial = ComputationNode::leaf(|| 1.0);
+        // Aggressive => always cache, even for a trivial leaf that Adaptive/Conservative
+        // would refuse. Distinguishes from `Default::default()` (which is Adaptive).
+        assert!(context.should_cache_node(&trivial));
+    }
+
+    #[test]
+    fn test_should_cache_node_conservative_boundary() {
+        let context = SampleContext::with_caching_strategy(CachingStrategy::Conservative);
+
+        let depth2 = ComputationNode::binary_op(
+            ComputationNode::leaf(|| 1.0),
+            ComputationNode::leaf(|| 2.0),
+            BinaryOperation::Add,
+        );
+        assert_eq!(depth2.depth(), 2);
+        assert!(!context.should_cache_node(&depth2));
+
+        let depth3 =
+            ComputationNode::binary_op(depth2, ComputationNode::leaf(|| 3.0), BinaryOperation::Add);
+        assert_eq!(depth3.depth(), 3);
+        assert!(context.should_cache_node(&depth3));
+    }
+
+    #[test]
+    fn test_should_cache_node_adaptive_boundary() {
+        let context = SampleContext::with_caching_strategy(CachingStrategy::Adaptive);
+
+        let complexity5 = ComputationNode::map(
+            ComputationNode::binary_op(
+                ComputationNode::leaf(|| 1.0),
+                ComputationNode::leaf(|| 2.0),
+                BinaryOperation::Add,
+            ),
+            |x| x,
+        );
+        assert_eq!(complexity5.compute_complexity(), 5);
+        assert!(!context.should_cache_node(&complexity5));
+
+        let complexity6 = ComputationNode::binary_op(
+            ComputationNode::map(ComputationNode::leaf(|| 1.0), |x| x),
+            ComputationNode::map(ComputationNode::leaf(|| 2.0), |x| x),
+            BinaryOperation::Add,
+        );
+        assert_eq!(complexity6.compute_complexity(), 6);
+        assert!(context.should_cache_node(&complexity6));
+    }
+
+    #[test]
+    fn test_adaptive_sampling_get_set() {
+        let mut context = SampleContext::new();
+        assert_eq!(context.adaptive_sampling().min_samples, 100);
+
+        let custom = AdaptiveSampling {
+            min_samples: 42,
+            max_samples: 999,
+            error_threshold: 0.05,
+            growth_factor: 2.0,
+        };
+        context.set_adaptive_sampling(custom);
+        assert_eq!(context.adaptive_sampling().min_samples, 42);
+        assert_eq!(context.adaptive_sampling().max_samples, 999);
+    }
+
+    #[test]
+    fn test_node_shape_metrics_leaf() {
+        let leaf = ComputationNode::leaf(|| 1.0);
+        assert_eq!(leaf.node_count(), 1);
+        assert_eq!(leaf.depth(), 1);
+        assert_eq!(leaf.compute_complexity(), 1);
+        assert!(!leaf.has_conditionals());
+    }
+
+    #[test]
+    fn test_node_shape_metrics_binary_op() {
+        let node = ComputationNode::binary_op(
+            ComputationNode::leaf(|| 1.0),
+            ComputationNode::leaf(|| 2.0),
+            BinaryOperation::Add,
+        );
+        assert_eq!(node.node_count(), 3);
+        assert_eq!(node.depth(), 2);
+        assert_eq!(node.compute_complexity(), 4);
+        assert!(!node.has_conditionals());
+    }
+
+    #[test]
+    fn test_node_shape_metrics_unary_op() {
+        let node = ComputationNode::map(ComputationNode::leaf(|| 1.0), |x| x * 2.0);
+        assert_eq!(node.node_count(), 2);
+        assert_eq!(node.depth(), 2);
+        assert_eq!(node.compute_complexity(), 2);
+        assert!(!node.has_conditionals());
+    }
+
+    #[test]
+    fn test_node_shape_metrics_nested_binary_op() {
+        let inner = ComputationNode::binary_op(
+            ComputationNode::leaf(|| 1.0),
+            ComputationNode::leaf(|| 2.0),
+            BinaryOperation::Add,
+        );
+        let outer =
+            ComputationNode::binary_op(inner, ComputationNode::leaf(|| 3.0), BinaryOperation::Mul);
+        assert_eq!(outer.node_count(), 5);
+        assert_eq!(outer.depth(), 3);
+        assert_eq!(outer.compute_complexity(), 7);
+    }
+
+    #[test]
+    fn test_node_shape_metrics_conditional() {
+        let node = ComputationNode::conditional(
+            ComputationNode::leaf(|| true),
+            ComputationNode::leaf(|| 1.0),
+            ComputationNode::leaf(|| 2.0),
+        );
+        assert_eq!(node.node_count(), 4);
+        assert_eq!(node.depth(), 2);
+        assert_eq!(node.compute_complexity(), 8);
+        assert!(node.has_conditionals());
+    }
+
+    #[test]
+    fn test_has_conditionals_propagates_through_binary_op() {
+        // Left is a conditional (true), right is a plain leaf (false): only `||`
+        // (not `&&`) makes this observably true.
+        let conditional = ComputationNode::conditional(
+            ComputationNode::leaf(|| true),
+            ComputationNode::leaf(|| 1.0),
+            ComputationNode::leaf(|| 2.0),
+        );
+        let wrapped = ComputationNode::binary_op(
+            conditional,
+            ComputationNode::leaf(|| 3.0),
+            BinaryOperation::Add,
+        );
+        assert!(wrapped.has_conditionals());
+    }
+
+    #[test]
+    fn test_check_addition_identities_both_orders_and_no_match() {
+        let x = ComputationNode::leaf(|| 5.0);
+        let zero = ComputationNode::leaf(|| 0.0);
+        let nonzero = ComputationNode::leaf(|| 3.0);
+        // The "x + 0" arm matches whenever the RIGHT side is a Leaf, regardless
+        // of the left side, so it shadows the "0 + x" arm unless the right side
+        // is something other than a Leaf.
+        let non_leaf = ComputationNode::binary_op(x.clone(), nonzero.clone(), BinaryOperation::Add);
+
+        // x + 0 = x
+        assert!(GraphOptimizer::check_addition_identities(&x, &zero).is_some());
+        // 0 + x = x
+        assert!(GraphOptimizer::check_addition_identities(&zero, &non_leaf).is_some());
+        // neither side is zero: no identity applies
+        assert!(GraphOptimizer::check_addition_identities(&x, &nonzero).is_none());
+        // left is a Leaf but not zero, right is not a Leaf: the "0 + x" arm's
+        // guard must actually check is_constant_zero, not always match.
+        assert!(GraphOptimizer::check_addition_identities(&nonzero, &non_leaf).is_none());
+    }
+
+    #[test]
+    fn test_check_subtraction_identities_match_and_no_match() {
+        let x = ComputationNode::leaf(|| 5.0);
+        let zero = ComputationNode::leaf(|| 0.0);
+        let nonzero = ComputationNode::leaf(|| 3.0);
+
+        // x - 0 = x
+        assert!(GraphOptimizer::check_subtraction_identities(&x, &zero).is_some());
+        assert!(GraphOptimizer::check_subtraction_identities(&x, &nonzero).is_none());
+    }
+
+    #[test]
+    fn test_check_multiplication_identities_all_orders_and_no_match() {
+        let x = ComputationNode::leaf(|| 5.0);
+        let zero = ComputationNode::leaf(|| 0.0);
+        let one = ComputationNode::leaf(|| 1.0);
+        let nonzero = ComputationNode::leaf(|| 3.0);
+        // Same arm-shadowing consideration as addition: the "x op leaf" arms
+        // match whenever the right side is a Leaf, so the "leaf op x" arms
+        // need a non-Leaf right side to be reachable.
+        let non_leaf = ComputationNode::binary_op(x.clone(), nonzero.clone(), BinaryOperation::Add);
+
+        // x * 0 = 0
+        assert!(GraphOptimizer::check_multiplication_identities(&x, &zero).is_some());
+        // 0 * x = 0
+        assert!(GraphOptimizer::check_multiplication_identities(&zero, &non_leaf).is_some());
+        // x * 1 = x
+        assert!(GraphOptimizer::check_multiplication_identities(&x, &one).is_some());
+        // 1 * x = x
+        assert!(GraphOptimizer::check_multiplication_identities(&one, &non_leaf).is_some());
+        // no identity
+        assert!(GraphOptimizer::check_multiplication_identities(&x, &nonzero).is_none());
+        // left is a Leaf but neither zero nor one, right is not a Leaf: both
+        // the "0 * x" and "1 * x" arms' guards must actually check their
+        // respective is_constant_zero/is_constant_one, not always match.
+        assert!(GraphOptimizer::check_multiplication_identities(&nonzero, &non_leaf).is_none());
+    }
+
+    #[test]
+    fn test_check_division_identities_match_and_no_match() {
+        let x = ComputationNode::leaf(|| 5.0);
+        let one = ComputationNode::leaf(|| 1.0);
+        let nonzero = ComputationNode::leaf(|| 3.0);
+
+        // x / 1 = x
+        assert!(GraphOptimizer::check_division_identities(&x, &one).is_some());
+        assert!(GraphOptimizer::check_division_identities(&x, &nonzero).is_none());
+    }
+
+    #[test]
+    fn test_is_constant_zero_and_one() {
+        let zero_fn: Arc<dyn Fn() -> f64 + Send + Sync> = Arc::new(|| 0.0);
+        let one_fn: Arc<dyn Fn() -> f64 + Send + Sync> = Arc::new(|| 1.0);
+
+        assert!(GraphOptimizer::is_constant_zero(&zero_fn));
+        assert!(!GraphOptimizer::is_constant_zero(&one_fn));
+        assert!(GraphOptimizer::is_constant_one(&one_fn));
+        assert!(!GraphOptimizer::is_constant_one(&zero_fn));
+    }
+
+    #[test]
+    fn test_is_constant_generic() {
+        let const_fn: Arc<dyn Fn() -> f64 + Send + Sync> = Arc::new(|| 7.0);
+        assert!(GraphOptimizer::is_constant(&const_fn));
+
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let counter2 = counter.clone();
+        let varying_fn: Arc<dyn Fn() -> f64 + Send + Sync> =
+            Arc::new(move || counter2.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        assert!(!GraphOptimizer::is_constant(&varying_fn));
+    }
+
+    #[test]
+    fn test_is_constant_bool() {
+        let const_fn: Arc<dyn Fn() -> bool + Send + Sync> = Arc::new(|| true);
+        assert!(GraphOptimizer::is_constant_bool(&const_fn));
+
+        let toggle = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let toggle2 = toggle.clone();
+        let varying_fn: Arc<dyn Fn() -> bool + Send + Sync> =
+            Arc::new(move || toggle2.fetch_xor(true, std::sync::atomic::Ordering::Relaxed));
+        assert!(!GraphOptimizer::is_constant_bool(&varying_fn));
+    }
+
+    #[test]
+    fn test_to_dot_node_ids_increment_sequentially() {
+        // If add_node_to_dot's `*node_id += 1` regressed to `*= 1`, every node
+        // would be assigned id 0 instead of sequential ids.
+        let left = ComputationNode::leaf(|| 1.0);
+        let right = ComputationNode::leaf(|| 2.0);
+        let add = ComputationNode::binary_op(left, right, BinaryOperation::Add);
+
+        let dot = GraphVisualizer::to_dot(&add);
+
+        assert!(dot.contains("0 [label=\"Add\""));
+        assert!(dot.contains("1 [label=\"Leaf\""));
+        assert!(dot.contains("2 [label=\"Leaf\""));
+        assert!(dot.contains("0 -> 1;"));
+        assert!(dot.contains("0 -> 2;"));
+    }
+
+    #[test]
+    fn test_profiler_get_stats_average_matches_total_over_count() {
+        let mut profiler = GraphProfiler::new();
+        profiler.profile_execution("op", || 1 + 1);
+        profiler.profile_execution("op", || 2 + 2);
+        profiler.profile_execution("op", || 3 + 3);
+
+        let stats = profiler.get_stats("op").unwrap();
+        assert_eq!(stats.count, 3);
+        // Independently recompute the average/count relationship; catches
+        // `average = total / count` regressing to `total * count`.
+        assert_eq!(
+            stats.average,
+            stats.total / u32::try_from(stats.count).unwrap()
+        );
+    }
 }

--- a/src/distributions.rs
+++ b/src/distributions.rs
@@ -906,4 +906,152 @@ mod tests {
         let samples: Vec<u32> = geometric.take_samples(100);
         assert!(samples.iter().all(|&x| x == 1));
     }
+
+    #[test]
+    fn test_mixture_weighted_selection_uses_correct_proportions() {
+        // Weights [1.0, 3.0] over total 4.0 => component 0 should be picked ~25% of the
+        // time. A `/` -> `%` or `/` -> `*` mutation in the weight-normalization leaves
+        // unnormalized weights (both >= total's modulus/product), which collapses
+        // selection onto whichever component is checked first in the cumulative array,
+        // producing a ratio far from 0.25. This also exercises the `<=` boundary in the
+        // cumulative lookup (a `<=` -> `>` mutation there swaps which component wins).
+        let low = Uncertain::normal(0.0, 0.001).unwrap();
+        let high = Uncertain::normal(100.0, 0.001).unwrap();
+        let mixture = Uncertain::mixture(vec![low, high], Some(vec![1.0, 3.0])).unwrap();
+        let samples: Vec<f64> = mixture.take_samples(10_000);
+        let low_ratio = samples.iter().filter(|&&x| x < 50.0).count() as f64 / samples.len() as f64;
+        assert!(
+            (low_ratio - 0.25).abs() < 0.05,
+            "expected ~25% low-component selections, got {low_ratio}"
+        );
+    }
+
+    #[test]
+    fn test_categorical_selection_uses_correct_proportions() {
+        // Same rationale as the mixture test above, for the categorical distribution's
+        // independent weight-normalization code path. Proportions are checked
+        // order-independently (HashMap iteration order is unspecified): "common"'s share
+        // is prob/total regardless of which key the loop visits first.
+        let mut probs = HashMap::new();
+        probs.insert("rare", 1.0);
+        probs.insert("common", 3.0);
+        let categorical = Uncertain::categorical(&probs).unwrap();
+        let samples: Vec<&str> = categorical.take_samples(10_000);
+        let common_ratio =
+            samples.iter().filter(|&&x| x == "common").count() as f64 / samples.len() as f64;
+        assert!(
+            (common_ratio - 0.75).abs() < 0.05,
+            "expected ~75% 'common' selections, got {common_ratio}"
+        );
+    }
+
+    #[test]
+    fn test_normal_distribution_moments() {
+        // Checks both mean AND standard deviation (the existing test only checked mean),
+        // with a tolerance tight enough to catch a corrupted Box-Muller formula (e.g. a
+        // `*` -> `/` swap inside the `sqrt(-2 ln u1) * cos(2*pi*u2)` term) while staying
+        // well outside normal sampling noise at this sample size.
+        let normal = Uncertain::normal(10.0, 3.0).unwrap();
+        let samples: Vec<f64> = normal.take_samples(20_000);
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        let variance =
+            samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / samples.len() as f64;
+        let std = variance.sqrt();
+        assert!((mean - 10.0).abs() < 0.15, "mean {mean}, expected 10.0");
+        assert!((std - 3.0).abs() < 0.25, "std {std}, expected 3.0");
+    }
+
+    #[test]
+    fn test_beta_distribution_moments() {
+        // Closed-form: mean = a/(a+b), variance = ab / ((a+b)^2 (a+b+1)).
+        // Deliberately skewed (2.0, 8.0) so an arithmetic corruption in the
+        // rejection-sampling accept condition or final ratio shows up clearly.
+        let alpha = 2.0;
+        let beta_param = 8.0;
+        let beta = Uncertain::beta(alpha, beta_param).unwrap();
+        let samples: Vec<f64> = beta.take_samples(20_000);
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        let expected_mean = alpha / (alpha + beta_param);
+        assert!(
+            (mean - expected_mean).abs() < 0.02,
+            "mean {mean}, expected {expected_mean}"
+        );
+
+        let variance =
+            samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / samples.len() as f64;
+        let expected_variance =
+            (alpha * beta_param) / ((alpha + beta_param).powi(2) * (alpha + beta_param + 1.0));
+        assert!(
+            (variance - expected_variance).abs() < 0.01,
+            "variance {variance}, expected {expected_variance}"
+        );
+    }
+
+    #[test]
+    fn test_beta_final_ratio_uses_division_not_modulo() {
+        // With alpha == beta == 0.5, x and y (both in the accepted region x+y<=1) are
+        // large enough relative to their sum that `x` alone (what a `/` -> `%` mutation
+        // in `x / (x + y)` would return, since 0 <= x < x+y makes `x % (x+y) == x`)
+        // has a mean far from the true `x / (x + y)` mean: simulation shows ~0.50 vs
+        // ~0.25 for these parameters, a much larger gap than the (2.0, 8.0) case above
+        // where the two coincidentally land close together.
+        let alpha = 0.5;
+        let beta_param = 0.5;
+        let beta = Uncertain::beta(alpha, beta_param).unwrap();
+        let samples: Vec<f64> = beta.take_samples(20_000);
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        let expected_mean = alpha / (alpha + beta_param);
+        assert!(
+            (mean - expected_mean).abs() < 0.05,
+            "mean {mean}, expected {expected_mean}"
+        );
+    }
+
+    #[test]
+    fn test_gamma_distribution_moments_shape_at_least_one() {
+        // Exercises the Marsaglia-Tsang branch (shape >= 1.0). Closed-form:
+        // mean = shape*scale, variance = shape*scale^2.
+        let shape = 3.0;
+        let scale = 2.0;
+        let gamma = Uncertain::gamma(shape, scale).unwrap();
+        let samples: Vec<f64> = gamma.take_samples(30_000);
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        let expected_mean = shape * scale;
+        assert!(
+            (mean - expected_mean).abs() < expected_mean * 0.1,
+            "mean {mean}, expected {expected_mean}"
+        );
+
+        let variance =
+            samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / samples.len() as f64;
+        let expected_variance = shape * scale * scale;
+        assert!(
+            (variance - expected_variance).abs() < expected_variance * 0.2,
+            "variance {variance}, expected {expected_variance}"
+        );
+    }
+
+    #[test]
+    fn test_gamma_distribution_moments_shape_below_one() {
+        // Exercises the shape < 1.0 transformation branch (gamma_1_plus_shape *
+        // u.powf(1/shape)), which the shape >= 1.0 test above never reaches.
+        let shape = 0.5;
+        let scale = 3.0;
+        let gamma = Uncertain::gamma(shape, scale).unwrap();
+        let samples: Vec<f64> = gamma.take_samples(30_000);
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        let expected_mean = shape * scale;
+        assert!(
+            (mean - expected_mean).abs() < expected_mean * 0.2,
+            "mean {mean}, expected {expected_mean}"
+        );
+
+        let variance =
+            samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / samples.len() as f64;
+        let expected_variance = shape * scale * scale;
+        assert!(
+            (variance - expected_variance).abs() < expected_variance * 0.3,
+            "variance {variance}, expected {expected_variance}"
+        );
+    }
 }

--- a/src/hypothesis.rs
+++ b/src/hypothesis.rs
@@ -375,6 +375,18 @@ mod tests {
     use super::*;
     use crate::operations::Comparison;
 
+    /// Produces an `Uncertain<bool>` that deterministically cycles through `pattern`
+    /// in order (no randomness), so tests can assert exact expected values instead of
+    /// loose statistical tolerances.
+    fn deterministic_bool_cycle(pattern: Vec<bool>) -> Uncertain<bool> {
+        let idx = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let pattern = std::sync::Arc::new(pattern);
+        Uncertain::new(move || {
+            let i = idx.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % pattern.len();
+            pattern[i]
+        })
+    }
+
     #[test]
     fn test_probability_exceeds() {
         let always_true = Uncertain::point(true);
@@ -423,6 +435,101 @@ mod tests {
     }
 
     #[test]
+    fn test_evaluate_hypothesis_certain_true_exact_samples() {
+        // With deterministic all-true evidence, threshold=0.5, default confidence
+        // (alpha=beta=0.05), epsilon=0.05, batch_size=1, the SPRT log-likelihood-ratio
+        // crosses the upper (accept H1) boundary at exactly 15 samples. This exact
+        // count is sensitive to the `a`/`b` boundary formulas (lines ~148-149) and the
+        // LLR accumulation itself.
+        let certain_true = Uncertain::point(true);
+        let result = certain_true.evaluate_hypothesis(0.5, 0.95, 10_000, None, None, None, 1);
+        assert!(result.decision);
+        assert_eq!(result.samples_used, 15);
+    }
+
+    #[test]
+    fn test_evaluate_hypothesis_certain_false_exact_samples() {
+        let certain_false = Uncertain::point(false);
+        let result = certain_false.evaluate_hypothesis(0.5, 0.95, 10_000, None, None, None, 1);
+        assert!(!result.decision);
+        assert_eq!(result.samples_used, 15);
+    }
+
+    #[test]
+    fn test_evaluate_hypothesis_extreme_error_rates_boundary_sensitive() {
+        // alpha=beta=0.5 makes `a` collapse to ln(1.0)=0.0 with the correct `/`
+        // formula, so a certain-false evidence source's very first (negative) LLR
+        // sample immediately triggers the H0-accept branch. Mutating that division to
+        // `%` makes beta_error % (1-alpha_error) == 0.0 (since both are 0.5), so
+        // `a` becomes ln(0.0) = -inf and the H0-accept branch never triggers,
+        // running all the way to max_samples instead of stopping after 1 sample.
+        let certain_false = Uncertain::point(false);
+        let result =
+            certain_false.evaluate_hypothesis(0.5, 0.95, 200, None, Some(0.5), Some(0.5), 1);
+        assert_eq!(result.samples_used, 1);
+        assert!(!result.decision);
+    }
+
+    #[test]
+    fn test_evaluate_hypothesis_batch_size_respects_remaining_budget() {
+        // With batch_size=10 and max_samples=25, the final batch must be clipped to
+        // the 5 remaining samples (25 - 20), not run a full batch of 10 and overshoot
+        // past max_samples. An alternating true/false evidence source keeps the LLR
+        // near zero throughout, so this exits via the max_samples fallback.
+        let alternating = deterministic_bool_cycle(vec![true, false]);
+        let result = alternating.evaluate_hypothesis(0.5, 0.95, 25, None, None, None, 10);
+        assert_eq!(result.samples_used, 25);
+        assert!(result.decision); // 13 true / 25 = 0.52 > 0.5
+    }
+
+    #[test]
+    fn test_evaluate_hypothesis_h0_accept_reports_exact_probability() {
+        // A mostly-false (1-in-5) evidence source accepts H0 (decision=false) at
+        // exactly 23 samples with 4 successes, so the returned `probability` field
+        // must be exactly 4/23. This targets the division computing `probability` on
+        // the H0-accept return path specifically (a separate return statement from
+        // the fallback path tested elsewhere).
+        let mostly_false = deterministic_bool_cycle(vec![false, false, false, false, true]);
+        let result = mostly_false.evaluate_hypothesis(0.5, 0.95, 10_000, None, None, None, 1);
+        assert!(!result.decision);
+        assert_eq!(result.samples_used, 23);
+        assert!((result.probability - 4.0 / 23.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_evaluate_hypothesis_fallback_decision_uses_strict_greater_than() {
+        // max_samples=1 with certain-true evidence can't cross either SPRT boundary
+        // in a single sample, so it exits via the max_samples fallback with
+        // decision computed directly from `final_p > threshold`. final_p=1.0 clearly
+        // exceeds threshold=0.3, distinguishing `>` from `<` (unlike the 0.5-vs-0.5
+        // exact-tie case in the other fallback test, which can't tell them apart).
+        let certain_true = Uncertain::point(true);
+        let result = certain_true.evaluate_hypothesis(0.3, 0.95, 1, None, None, None, 1);
+        assert_eq!(result.samples_used, 1);
+        assert!(result.decision);
+    }
+
+    // NOTE: `p0.clamp(1e-10, 1.0 - 1e-10)` / `p1.clamp(1e-10, 1.0 - 1e-10)` (the
+    // `p0_clamped`/`p1_clamped` computation) have an equivalent-mutant upper bound:
+    // p0/p1 are already clamped to [0.001, 0.999] earlier, and 0.999 < 1.0 - 1e-10
+    // always, so that upper bound never binds regardless of whether it's computed as
+    // `1.0 - 1e-10`, `1.0 + 1e-10`, or `1.0 / 1e-10` -- no test can distinguish these
+    // without first changing the earlier [0.001, 0.999] clamp.
+
+    #[test]
+    fn test_evaluate_hypothesis_fallback_when_llr_never_crosses() {
+        // An alternating true/false evidence source keeps the LLR oscillating near
+        // zero, never reaching the a/b thresholds, so this must exhaust max_samples
+        // via the `while samples < max_samples` loop condition itself and fall back
+        // to `final_p > threshold`. With max_samples=10 and exactly half the samples
+        // true, final_p == 0.5 == threshold, so `>` (not `<=`) must yield `false`.
+        let alternating = deterministic_bool_cycle(vec![true, false]);
+        let result = alternating.evaluate_hypothesis(0.5, 0.95, 10, None, None, None, 1);
+        assert_eq!(result.samples_used, 10);
+        assert!(!result.decision);
+    }
+
+    #[test]
     fn test_sprt_efficiency() {
         // Clear cases should be decided quickly
         let certain_true = Uncertain::point(true);
@@ -442,6 +549,38 @@ mod tests {
 
         // These tests are probabilistic but should generally hold
         assert!(!high_confidence); // Very unlikely to be 95% confident
+    }
+
+    #[test]
+    fn test_estimate_probability_exact() {
+        let condition = deterministic_bool_cycle(vec![true, false, true]);
+        // 2 of 3 samples true, deterministically.
+        assert!((condition.estimate_probability(3) - 2.0 / 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_bayesian_update_evidence_present_exact() {
+        // evidence_prob = 1.0 (point(true), always > 0.5) takes the "present" branch:
+        // posterior = (likelihood_given_true * prior) / evidence_total
+        let evidence = Uncertain::point(true);
+        let posterior = Uncertain::bayesian_update(0.5, &evidence, 0.8, 0.2, 10);
+        assert!((posterior - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_bayesian_update_evidence_at_exact_boundary_takes_absent_branch() {
+        // evidence_prob == 0.5 exactly is NOT > 0.5, so this must take the "absent"
+        // branch: posterior = ((1 - likelihood_given_true) * prior) / (1 - evidence_total)
+        let evidence = deterministic_bool_cycle(vec![true, false]);
+        assert!((evidence.estimate_probability(2) - 0.5).abs() < 1e-12);
+
+        let posterior = Uncertain::bayesian_update(0.5, &evidence, 0.8, 0.2, 2);
+        // evidence_total = 0.8*0.5 + 0.2*0.5 = 0.5
+        // posterior = (1-0.8)*0.5 / (1-0.5) = 0.1/0.5 = 0.2
+        assert!(
+            (posterior - 0.2).abs() < 1e-9,
+            "expected 0.2, got {posterior}"
+        );
     }
 
     #[test]
@@ -478,6 +617,49 @@ mod tests {
         assert_eq!(results[0].0, "warm");
         // Can't guarantee the decision due to randomness, but we can check structure
         assert!(results[0].1.samples_used > 0);
+    }
+
+    #[test]
+    fn test_test_all_corrected_alpha_exact() {
+        // corrected_alpha = overall_alpha / hypotheses.len(); confidence_level =
+        // 1.0 - corrected_alpha. HypothesisResult passes confidence_level straight
+        // through, so this is an exact, sampling-independent check of that formula.
+        let hypotheses = vec![
+            Uncertain::point(true),
+            Uncertain::point(true),
+            Uncertain::point(true),
+        ];
+        let names = vec!["a", "b", "c"];
+        let tester = MultipleHypothesisTester::new(hypotheses, names);
+        let results = tester.test_all(0.06, 100);
+
+        // corrected_alpha = 0.06 / 3 = 0.02; confidence_level = 1.0 - 0.02 = 0.98
+        for (_, result) in &results {
+            assert!(
+                (result.confidence_level - 0.98).abs() < 1e-9,
+                "expected confidence_level 0.98, got {}",
+                result.confidence_level
+            );
+        }
+    }
+
+    #[test]
+    fn test_test_all_empty_hypotheses_uses_overall_alpha() {
+        let tester = MultipleHypothesisTester::new(vec![], vec![]);
+        let results = tester.test_all(0.05, 100);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_find_most_likely_all_zero_probability_returns_none() {
+        // best_prob starts at 0.0; with the correct strict `>` comparison, a
+        // hypothesis whose probability is also exactly 0.0 must NOT overwrite the
+        // "no best yet" state. Mutating `>` to `>=` would make the first zero-
+        // probability hypothesis incorrectly "win".
+        let hypotheses = vec![Uncertain::point(false), Uncertain::point(false)];
+        let names = vec!["a", "b"];
+        let tester = MultipleHypothesisTester::new(hypotheses, names);
+        assert_eq!(tester.find_most_likely(10), None);
     }
 
     #[test]

--- a/src/operations/arithmetic.rs
+++ b/src/operations/arithmetic.rs
@@ -400,4 +400,53 @@ mod tests {
         let y = Uncertain::point(2.0);
         assert!((y.pow(3.0).sample() - 8.0_f64).abs() < f64::EPSILON);
     }
+
+    #[test]
+    fn test_arithmetic_zero_and_one() {
+        assert!((<f64 as Arithmetic>::zero() - 0.0).abs() < f64::EPSILON);
+        assert!((<f64 as Arithmetic>::one() - 1.0).abs() < f64::EPSILON);
+        assert!((<f32 as Arithmetic>::zero() - 0.0).abs() < f32::EPSILON);
+        assert!((<f32 as Arithmetic>::one() - 1.0).abs() < f32::EPSILON);
+        assert_eq!(<i32 as Arithmetic>::zero(), 0);
+        assert_eq!(<i32 as Arithmetic>::one(), 1);
+        assert_eq!(<i64 as Arithmetic>::zero(), 0);
+        assert_eq!(<i64 as Arithmetic>::one(), 1);
+        assert_eq!(<u32 as Arithmetic>::zero(), 0);
+        assert_eq!(<u32 as Arithmetic>::one(), 1);
+        assert_eq!(<u64 as Arithmetic>::zero(), 0);
+        assert_eq!(<u64 as Arithmetic>::one(), 1);
+    }
+
+    #[test]
+    fn test_scalar_minus_uncertain() {
+        let result = 5.0 - Uncertain::point(2.0);
+        assert!((result.sample() - 3.0_f64).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_scalar_times_uncertain() {
+        let result = 3.0 * Uncertain::point(2.0);
+        assert!((result.sample() - 6.0_f64).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_uncertain_div_scalar() {
+        let result = Uncertain::point(10.0) / 2.0;
+        assert!((result.sample() - 5.0_f64).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_scalar_div_uncertain() {
+        let result = 10.0 / Uncertain::point(2.0);
+        assert!((result.sample() - 5.0_f64).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_negation() {
+        let result = -Uncertain::point(5.0);
+        assert!((result.sample() - (-5.0_f64)).abs() < f64::EPSILON);
+
+        let result_neg = -Uncertain::point(-3.0);
+        assert!((result_neg.sample() - 3.0_f64).abs() < f64::EPSILON);
+    }
 }

--- a/src/operations/comparison.rs
+++ b/src/operations/comparison.rs
@@ -235,4 +235,78 @@ mod tests {
         let true_ratio = samples.iter().filter(|&&x| x).count() as f64 / samples.len() as f64;
         assert!(true_ratio > 0.8);
     }
+
+    #[test]
+    fn test_comparison_trait_gt_boundary() {
+        let value = Uncertain::point(5.0);
+        assert!(!Comparison::gt(&value, 5.0).sample());
+        assert!(Comparison::gt(&value, 4.0).sample());
+        assert!(!Comparison::gt(&value, 6.0).sample());
+    }
+
+    #[test]
+    fn test_gt_uncertain_boundary() {
+        let equal_a = Uncertain::point(5.0);
+        let equal_b = Uncertain::point(5.0);
+        assert!(!equal_a.gt_uncertain(&equal_b).sample());
+
+        let larger = Uncertain::point(5.0);
+        let smaller = Uncertain::point(3.0);
+        assert!(larger.gt_uncertain(&smaller).sample());
+        assert!(!smaller.gt_uncertain(&larger).sample());
+    }
+
+    #[test]
+    fn test_comparison_trait_lt_boundary() {
+        let value = Uncertain::point(5.0);
+        assert!(Comparison::lt(&value, 6.0).sample());
+        assert!(!Comparison::lt(&value, 5.0).sample());
+        assert!(!Comparison::lt(&value, 4.0).sample());
+    }
+
+    #[test]
+    fn test_comparison_trait_ge_boundary() {
+        let value = Uncertain::point(5.0);
+        assert!(Comparison::ge(&value, 5.0).sample());
+        assert!(Comparison::ge(&value, 4.0).sample());
+        assert!(!Comparison::ge(&value, 6.0).sample());
+    }
+
+    #[test]
+    fn test_comparison_trait_le_boundary() {
+        let value = Uncertain::point(5.0);
+        assert!(Comparison::le(&value, 5.0).sample());
+        assert!(Comparison::le(&value, 6.0).sample());
+        assert!(!Comparison::le(&value, 4.0).sample());
+    }
+
+    #[test]
+    fn test_comparison_trait_eq_and_ne() {
+        let value = Uncertain::point(5.0);
+        assert!(Comparison::eq(&value, 5.0).sample());
+        assert!(!Comparison::eq(&value, 4.0).sample());
+        assert!(Comparison::ne(&value, 4.0).sample());
+        assert!(!Comparison::ne(&value, 5.0).sample());
+    }
+
+    #[test]
+    fn test_lt_uncertain_boundary() {
+        let equal_a = Uncertain::point(5.0);
+        let equal_b = Uncertain::point(5.0);
+        assert!(!equal_a.lt_uncertain(&equal_b).sample());
+
+        let smaller = Uncertain::point(3.0);
+        let larger = Uncertain::point(5.0);
+        assert!(smaller.lt_uncertain(&larger).sample());
+        assert!(!larger.lt_uncertain(&smaller).sample());
+    }
+
+    #[test]
+    fn test_eq_uncertain_boundary() {
+        let a = Uncertain::point(5.0);
+        let b = Uncertain::point(5.0);
+        let c = Uncertain::point(6.0);
+        assert!(a.eq_uncertain(&b).sample());
+        assert!(!a.eq_uncertain(&c).sample());
+    }
 }

--- a/src/operations/logical.rs
+++ b/src/operations/logical.rs
@@ -300,6 +300,17 @@ mod tests {
     }
 
     #[test]
+    fn test_logical_xor() {
+        let t = Uncertain::point(true);
+        let f = Uncertain::point(false);
+
+        assert!(!t.xor(&t).sample());
+        assert!(t.xor(&f).sample());
+        assert!(f.xor(&t).sample());
+        assert!(!f.xor(&f).sample());
+    }
+
+    #[test]
     fn test_shared_variable_semantics() {
         // Test that logical operations work (shared variable semantics need further development)
         let x = Uncertain::normal(0.0, 1.0).unwrap();

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1690,4 +1690,504 @@ mod tests {
         let total: usize = histogram.values().sum();
         assert_eq!(total, 300);
     }
+
+    // No seeded RNG yet, so this cycles through a fixed sequence via an atomic
+    // counter to make exact numeric assertions possible instead of relying on
+    // statistical tolerance, which doesn't distinguish e.g. `-` from `+` in a formula.
+    fn deterministic_sequence<T: Clone + Send + Sync + 'static>(values: Vec<T>) -> Uncertain<T> {
+        let idx = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let values = std::sync::Arc::new(values);
+        Uncertain::new(move || {
+            let i = idx.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % values.len();
+            values[i].clone()
+        })
+    }
+
+    #[test]
+    fn test_lazy_stats_quantile_interpolation_exact() {
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        let stats = seq.lazy_stats(5);
+        // position = 0.3 * 4 = 1.2 -> lower=1 (20.0), upper=2 (30.0), weight=0.2
+        // 20.0 + 0.2 * (30.0 - 20.0) = 22.0
+        assert!((stats.quantile(0.3) - 22.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_lazy_stats_quantile_equal_branch_clamp() {
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        let stats = seq.lazy_stats(5);
+        // q=1.5 (out of the documented [0,1] range, not yet validated -- see spec 18)
+        // gives an exact-integer position (6.0), landing in the equal-index branch,
+        // which must clamp to the last valid index rather than reading out of bounds.
+        assert!((stats.quantile(1.5) - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_lazy_stats_quantile_interp_branch_clamp() {
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        let stats = seq.lazy_stats(5);
+        // q=1.125 gives position=4.5: lower_idx=4 (in bounds), upper_idx=5 (must
+        // clamp to 4, the last valid index) in the interpolation branch.
+        assert!((stats.quantile(1.125) - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_lazy_stats_confidence_interval_exact() {
+        let seq = deterministic_sequence((1..=10).map(f64::from).collect::<Vec<_>>());
+        let stats = seq.lazy_stats(10);
+        let (lower, upper) = stats.confidence_interval(0.8);
+        assert!((lower - 1.0).abs() < 1e-9);
+        assert!((upper - 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_lazy_stats_confidence_interval_lower_clamp() {
+        let seq = deterministic_sequence((1..=10).map(f64::from).collect::<Vec<_>>());
+        let stats = seq.lazy_stats(10);
+        // confidence=-1.0 is out of the documented (0,1) range (not yet validated --
+        // see spec 18), but it drives lower_idx's raw (pre-clamp) value past the
+        // array bound, exercising the lower-index clamp specifically.
+        let (lower, upper) = stats.confidence_interval(-1.0);
+        assert!((lower - 10.0).abs() < 1e-9);
+        assert!((upper - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_lazy_stats_confidence_interval_upper_clamp() {
+        let seq = deterministic_sequence((1..=10).map(f64::from).collect::<Vec<_>>());
+        let stats = seq.lazy_stats(10);
+        // confidence=3.0 drives upper_idx's raw (pre-clamp) value past the array
+        // bound, exercising the upper-index clamp specifically.
+        let (lower, upper) = stats.confidence_interval(3.0);
+        assert!((lower - 1.0).abs() < 1e-9);
+        assert!((upper - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_uncertain_confidence_interval_exact() {
+        let seq = deterministic_sequence((1..=10).map(f64::from).collect::<Vec<_>>());
+        let (lower, upper) = seq.confidence_interval(0.8, 10);
+        assert!((lower - 1.0).abs() < 1e-9);
+        assert!((upper - 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_uncertain_confidence_interval_lower_clamp() {
+        let seq = deterministic_sequence((1..=10).map(f64::from).collect::<Vec<_>>());
+        let (lower, upper) = seq.confidence_interval(-1.0, 10);
+        assert!((lower - 10.0).abs() < 1e-9);
+        assert!((upper - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_uncertain_confidence_interval_upper_clamp() {
+        let seq = deterministic_sequence((1..=10).map(f64::from).collect::<Vec<_>>());
+        let (lower, upper) = seq.confidence_interval(3.0, 10);
+        assert!((lower - 1.0).abs() < 1e-9);
+        assert!((upper - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_uncertain_quantile_interpolation_exact() {
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        assert!((seq.quantile(0.3, 5) - 22.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_uncertain_quantile_equal_branch_clamp() {
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        assert!((seq.quantile(1.5, 5) - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_uncertain_quantile_interp_branch_clamp() {
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        assert!((seq.quantile(1.125, 5) - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_ensure_samples_exact_progression() {
+        // ensure_samples/progressive_stats/current_samples are private fields/methods,
+        // but this test module is a descendant of their defining module, so they're
+        // directly accessible -- avoids needing to reverse-engineer exact behavior
+        // through the public convergence-loop API alone.
+        let seq = deterministic_sequence(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+        let config = AdaptiveSampling {
+            min_samples: 3,
+            max_samples: 100,
+            error_threshold: 0.0001,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&seq, &config);
+
+        stats.ensure_samples(3);
+        assert_eq!(stats.progressive_stats.borrow().count(), 3);
+        assert!((stats.progressive_stats.borrow().mean() - 2.0).abs() < 1e-9); // [1,2,3]
+
+        // current == target: a no-op either way (additional_samples would be 0
+        // regardless of `<` vs `<=` here), so this call intentionally isn't used
+        // to distinguish that particular mutant -- see the fork report.
+        stats.ensure_samples(3);
+        assert_eq!(stats.progressive_stats.borrow().count(), 3);
+
+        stats.ensure_samples(7);
+        // additional_samples = 7 - 3 = 4, consuming the next 4 values [4,5,6,7].
+        // A `target_samples - *current` -> `target_samples + *current` mutation
+        // would instead consume 7 + 3 = 10 values here.
+        assert_eq!(stats.progressive_stats.borrow().count(), 7);
+        assert!((stats.progressive_stats.borrow().mean() - 4.0).abs() < 1e-9); // [1..7]
+    }
+
+    #[test]
+    fn test_adaptive_mean_stops_before_min_samples_check_is_premature() {
+        // A loose error_threshold means that if the `sample_count > min_samples`
+        // guard is mutated to `>=`, the convergence check would (wrongly) run on
+        // the very first iteration and immediately accept it, terminating early
+        // with fewer samples than correct code would use.
+        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = call_count.clone();
+        let source = Uncertain::new(move || {
+            counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            5.0
+        });
+        let config = AdaptiveSampling {
+            min_samples: 10,
+            max_samples: 1000,
+            error_threshold: 2.0,
+            growth_factor: 1.5,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let mean = stats.mean();
+        assert!((mean - 5.0).abs() < 1e-9);
+        // Correct: iteration 1 (target 10) skips the premature check; iteration 2
+        // (target 15) converges (relative_error 0.0 < 2.0), so current_samples
+        // ends at the cumulative target of 15, not 10.
+        assert_eq!(*stats.current_samples.borrow(), 15);
+    }
+
+    #[test]
+    fn test_adaptive_mean_zero_mean_branch() {
+        // When the running mean is exactly 0.0, the code takes an absolute-difference
+        // branch instead of a relative one (avoiding a 0/0 division). A constant-zero
+        // source keeps the mean at exactly 0.0 for every sample_count, so mutating
+        // that `mean == 0.0` check to `!=` forces the relative (0.0/0.0 = NaN) branch,
+        // which never satisfies `< error_threshold` and so never converges early --
+        // it runs until sample_count hits max_samples instead.
+        let source = Uncertain::new(|| 0.0);
+        let config = AdaptiveSampling {
+            min_samples: 5,
+            max_samples: 50,
+            error_threshold: 0.01,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let mean = stats.mean();
+        assert!(mean.abs() < 1e-9);
+        assert_eq!(*stats.current_samples.borrow(), 10);
+    }
+
+    #[test]
+    fn test_adaptive_variance_stops_before_min_samples_check_is_premature() {
+        let source = Uncertain::new(|| 5.0);
+        let config = AdaptiveSampling {
+            min_samples: 10,
+            max_samples: 1000,
+            error_threshold: 2.0,
+            growth_factor: 1.5,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let variance = stats.variance();
+        assert!(variance.abs() < 1e-9); // constant source -> variance 0
+        assert_eq!(*stats.current_samples.borrow(), 15);
+    }
+
+    #[test]
+    fn test_adaptive_variance_zero_branch() {
+        let source = Uncertain::new(|| 0.0);
+        let config = AdaptiveSampling {
+            min_samples: 5,
+            max_samples: 50,
+            error_threshold: 0.01,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let variance = stats.variance();
+        assert!(variance.abs() < 1e-9);
+        assert_eq!(*stats.current_samples.borrow(), 10);
+    }
+
+    #[test]
+    fn test_expected_value_adaptive_stops_before_min_samples_check_is_premature() {
+        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = call_count.clone();
+        let source = Uncertain::new(move || {
+            counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            5.0
+        });
+        let config = AdaptiveSampling {
+            min_samples: 10,
+            max_samples: 1000,
+            error_threshold: 2.0,
+            growth_factor: 1.5,
+        };
+        let mean = source.expected_value_adaptive(&config);
+        assert!((mean - 5.0).abs() < 1e-9);
+        // Correct: skips the premature check at iteration 1 (10 samples), converges
+        // at iteration 2 (15 more samples, 25 total). A `>` -> `>=` mutation on the
+        // min_samples guard would instead accept convergence at iteration 1 (10 total).
+        assert_eq!(call_count.load(std::sync::atomic::Ordering::Relaxed), 25);
+    }
+
+    #[test]
+    fn test_mode_exact_with_dominant_value() {
+        // `*counts.entry(sample).or_insert(0) += 1` mutated to `*= 1` would leave
+        // every count at 0 forever, making the "mode" effectively an arbitrary pick
+        // among tied keys (HashMap iteration order isn't meaningful). Using a
+        // clearly dominant value against a wide spread of distinct singleton
+        // "noise" values makes it overwhelmingly unlikely that a broken (all-zero)
+        // tie-break would coincidentally land back on the dominant value.
+        let mut values = vec![7; 50];
+        values.extend(0..30); // 30 distinct singleton values: 0..29
+        let seq = deterministic_sequence(values.clone());
+        let mode = seq.mode(values.len());
+        assert_eq!(mode, Some(7));
+    }
+
+    #[test]
+    fn test_skewness_and_kurtosis_exact() {
+        let seq = deterministic_sequence(vec![1.0, 1.0, 1.0, 1.0, 10.0]);
+        // mean=2.8, population variance=12.96, std=3.6
+        // skewness = sum(((x-mean)/std)^3)/n = 1.5
+        // excess kurtosis = sum(((x-mean)/std)^4)/n - 3.0 = 0.25
+        assert!((seq.skewness(5) - 1.5).abs() < 1e-9);
+        assert!((seq.kurtosis(5) - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_median_absolute_deviation_exact() {
+        // An EVEN sample count is needed: `(len() - 1) / 2` and a mutated
+        // `(len() / 1) / 2` (i.e. `len() / 2`) happen to floor to the same integer
+        // index for odd lengths (e.g. both give 2 for len=5), masking that mutant.
+        let seq = deterministic_sequence(vec![10.0, 20.0, 30.0, 100.0]);
+        // quantile(0.5, 4): position=0.5*3=1.5 -> lower=20.0, upper=30.0, weight=0.5
+        // -> median = 25.0. deviations sorted = [5,5,15,75]; mad_index=(4-1)/2=1 -> 5.0
+        assert!((seq.median_absolute_deviation(4) - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_pdf_kde_and_log_likelihood_exact() {
+        // Asymmetric sample set around a non-zero x: a symmetric set (e.g.
+        // [0,1,-1,2,-2] evaluated at x=0) makes `(x - xi)` and a mutated
+        // `(x + xi)` square to the same value for every term, an accidental
+        // equivalence -- asymmetric data avoids that. bandwidth=2.0 (not 1.0)
+        // matters too: multiplying vs dividing by exactly 1.0 in the denominator
+        // gives the same result, masking a `sample_count * bandwidth` -> `/` mutant.
+        let seq = deterministic_sequence(vec![0.0, 1.0, 2.0, -1.5]);
+        let pdf = seq.pdf_kde(0.5, 4, 2.0);
+        assert!((pdf - 0.164_555_548_784_955_8).abs() < 1e-9);
+        let ll = seq.log_likelihood(0.5, 4, 2.0);
+        assert!((ll - (-1.804_507_083_195_324)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_correlation_exact() {
+        let x = deterministic_sequence(vec![1.0, 3.0, 2.0, 8.0, 5.0]);
+        let y = deterministic_sequence(vec![2.0, 1.0, 9.0, 4.0, 3.0]);
+        let correlation = x.correlation(&y, 5);
+        assert!((correlation - (-0.063_640_188_856_59)).abs() < 1e-9);
+    }
+
+    // NOTE ON EQUIVALENT MUTANTS (verified algebraically, not just "hard to test"):
+    // `correlation`'s numerator sums `(x - mean_x) * (y - mean_y)`. Mutating either
+    // `-` to `+` (statistics.rs:1075, both occurrences) does not change the sum:
+    // sum((x + mean_x) * (y - mean_y)) = sum((x - mean_x)*(y - mean_y)) + 2*mean_x*sum(y - mean_y),
+    // and sum(y - mean_y) over any dataset is always exactly 0 by definition of the
+    // mean. The same cancellation applies symmetrically to the y-side `-`. Verified
+    // numerically (see fork report) as well as algebraically.
+
+    #[test]
+    fn test_correlation_zero_variance_in_second_argument() {
+        // Mirrors the existing `test_correlation_zero_variance` (constant x) but with
+        // the constant on y instead, which is the side that must be checked to catch
+        // `var_x * var_y > 0.0` mutated to `var_x / var_y > 0.0`: with var_x > 0.0 and
+        // var_y == 0.0 exactly, the real code's `*` gives 0.0 (not > 0.0, correctly
+        // short-circuiting to a 0.0 result); the mutant's `/` gives `+inf` (`> 0.0` is
+        // true), so it proceeds to divide a numerator of 0.0 (since y is constant, every
+        // `y - mean_y` term is 0.0) by `sqrt(0.0)`, producing `NaN`.
+        let x = Uncertain::normal(0.0, 1.0).unwrap();
+        let y = Uncertain::new(|| 7.0);
+        let correlation = x.correlation(&y, 1000);
+        assert!(correlation.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_adaptive_mean_nonzero_relative_error_arithmetic() {
+        // An ever-increasing (non-repeating) source makes each iteration's
+        // progressive mean genuinely different from the last, so the relative-error
+        // arithmetic (`-`, `/`) actually matters -- a constant source gives 0/anything
+        // regardless of which operator is used, masking these mutants.
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 64,
+            error_threshold: 0.6,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let mean = stats.mean();
+        // Real: converges once sample_count reaches 8 (relative_error 0.5714 < 0.6);
+        // mean over the cumulative [0..7] range is (0+7)/2 = 3.5.
+        assert!((mean - 3.5).abs() < 1e-9);
+        assert_eq!(*stats.current_samples.borrow(), 8);
+    }
+
+    #[test]
+    fn test_adaptive_mean_convergence_threshold_is_strict() {
+        // Sets error_threshold to EXACTLY the relative_error value real code computes
+        // at n=8 (2.0/3.5). Strict `<` of two equal f64 values is false, so real code
+        // must NOT converge at n=8 -- it only converges at n=16, once relative_error
+        // (0.5333) genuinely drops below that fixed threshold. A `<` -> `<=` mutation
+        // would accept the n=8 boundary immediately instead.
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 1000,
+            error_threshold: 2.0 / 3.5,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let mean = stats.mean();
+        assert!((mean - 7.5).abs() < 1e-9); // mean over cumulative [0..15]
+        assert_eq!(*stats.current_samples.borrow(), 16);
+    }
+
+    #[test]
+    fn test_adaptive_variance_nonzero_relative_error_arithmetic() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        // Variance's relative-error trajectory for an ever-increasing source is very
+        // different from mean's (it grows toward ~0.75 rather than shrinking toward
+        // 0.5), so this needs its own threshold, tuned so the real computation
+        // converges at n=8 while the arithmetic mutants (which push relative_error to
+        // ~1.3-26, see fork report) don't.
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 64,
+            error_threshold: 0.73,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let variance = stats.variance();
+        // ProgressiveStats::variance over [0..7] (n=8): mean=3.5, sum_squares=140,
+        // (140 - 8*3.5^2)/(8-1) = 6.0.
+        assert!((variance - 6.0).abs() < 1e-9);
+        assert_eq!(*stats.current_samples.borrow(), 8);
+    }
+
+    #[test]
+    fn test_adaptive_variance_convergence_threshold_is_strict() {
+        // Mirrors test_adaptive_mean_convergence_threshold_is_strict for variance:
+        // threshold set to EXACTLY the real relative_error at n=8. Unlike mean's
+        // relative_error (which shrinks toward 0.5 for this source), variance's
+        // relative_error only *grows* past n=8 (toward ~0.75) -- so with a strict `<`,
+        // real code never converges via the primary check again and runs all the way
+        // to max_samples. A `<` -> `<=` mutation accepts the n=8 boundary immediately.
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        let v4 = 5.0_f64 / 3.0; // ProgressiveStats::variance over [0..3]
+        let v8 = 6.0_f64; // ProgressiveStats::variance over [0..7]
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 64,
+            error_threshold: (v8 - v4) / v8,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let variance = stats.variance();
+        assert!((variance - 346.666_666_666_666_7).abs() < 1e-6);
+        assert_eq!(*stats.current_samples.borrow(), 64);
+    }
+
+    #[test]
+    fn test_adaptive_variance_numerator_subtraction_not_division() {
+        // A `variance - prev_variance` -> `variance / prev_variance` mutation at this
+        // position algebraically cancels with the outer `/ variance`, leaving just
+        // `1 / prev_variance` -- a value that happens to still be < the threshold used
+        // in `test_adaptive_variance_nonzero_relative_error_arithmetic` (0.73), so that
+        // test alone doesn't catch it. A lower threshold (0.65) makes the real
+        // relative_error (which only grows, ~0.72-0.75, and never crosses 0.65) run to
+        // max_samples, while the mutant's `1/prev_variance` (0.6 at n=8) converges
+        // immediately -- clearly different final variances.
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 64,
+            error_threshold: 0.65,
+            growth_factor: 2.0,
+        };
+        let stats = AdaptiveLazyStats::new(&source, &config);
+        let variance = stats.variance();
+        // Real: never converges via the primary check, runs to max_samples=64.
+        // ProgressiveStats::variance over [0..63]: computed via the same formula.
+        assert!((variance - 346.666_666_666_666_7).abs() < 1e-6);
+        assert_eq!(*stats.current_samples.borrow(), 64);
+    }
+
+    #[test]
+    fn test_expected_value_adaptive_nonzero_relative_error_arithmetic() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        // Threshold tuned so the mutated `mean - prev_mean -> mean / prev_mean`
+        // (relative_error 0.667 at n=8) still converges at n=8 with this threshold,
+        // same as real code (0.8), so a *lower* threshold (0.75) is needed to force
+        // real code to continue to n=16 while the mutant still stops at n=8.
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 64,
+            error_threshold: 0.75,
+            growth_factor: 2.0,
+        };
+        let mean = source.expected_value_adaptive(&config);
+        // Real: relative_error at n=8 is 0.8 (not < 0.75), continues to n=16 where
+        // relative_error is 0.6154 (< 0.75) -> converges with mean = 19.5 (fresh draw
+        // of positions 12..27... i.e. the third batch; see fork report for the exact
+        // simulation). The `/` mutant's relative_error at n=8 (0.667) IS < 0.75,
+        // so it stops early with mean = 7.5.
+        assert!((mean - 19.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_expected_value_adaptive_convergence_threshold_is_strict() {
+        // Mirrors test_adaptive_mean_convergence_threshold_is_strict: threshold set to
+        // EXACTLY the real relative_error at n=8 (0.8). Strict `<` of equal values is
+        // false, so real code must continue past n=8; a `<` -> `<=` mutation would
+        // accept it immediately.
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let c = counter.clone();
+        let source =
+            Uncertain::new(move || c.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as f64);
+        let config = AdaptiveSampling {
+            min_samples: 4,
+            max_samples: 1000,
+            error_threshold: 0.8,
+            growth_factor: 2.0,
+        };
+        let mean = source.expected_value_adaptive(&config);
+        assert!((mean - 19.5).abs() < 1e-9);
+    }
 }

--- a/src/uncertain.rs
+++ b/src/uncertain.rs
@@ -509,11 +509,46 @@ mod tests {
     }
 
     #[test]
+    fn test_id_is_stable_and_unique() {
+        let a = Uncertain::new(|| 1.0_f64);
+        let b = Uncertain::new(|| 1.0_f64);
+        assert_ne!(a.id(), b.id());
+        assert_eq!(a.id(), a.id());
+    }
+
+    #[test]
+    fn test_take_samples_cached_returns_requested_length_and_real_data() {
+        let uniform = Uncertain::uniform(0.0, 100.0).unwrap();
+        let samples = uniform.take_samples_cached(500);
+        assert_eq!(samples.len(), 500);
+        // A uniform(0,100) sample set should not be all-0, all-1, or all--1.
+        assert!(!samples.iter().all(|&x| x == 0.0));
+        assert!(!samples.iter().all(|&x| x == 1.0));
+        assert!(!samples.iter().all(|&x| x == -1.0));
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        assert!((10.0..90.0).contains(&mean));
+    }
+
+    #[test]
     fn test_less_than() {
         let smaller = Uncertain::new(|| 1.0);
         let larger = Uncertain::new(|| 2.0);
         let comparison = smaller.less_than(&larger);
         assert!(comparison.sample());
+    }
+
+    #[test]
+    fn test_less_than_equal_values_is_false() {
+        let a = Uncertain::new(|| 5.0);
+        let b = Uncertain::new(|| 5.0);
+        assert!(!a.less_than(&b).sample());
+    }
+
+    #[test]
+    fn test_greater_than_equal_values_is_false() {
+        let a = Uncertain::new(|| 5.0);
+        let b = Uncertain::new(|| 5.0);
+        assert!(!a.greater_than(&b).sample());
     }
 
     #[test]
@@ -570,6 +605,21 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_ord_lt_gt_boundary() {
+        let a = Uncertain::point(5.0);
+        let b = Uncertain::point(5.0);
+        let smaller = Uncertain::point(3.0);
+        let larger = Uncertain::point(7.0);
+
+        assert!(!PartialOrd::lt(&a, &b));
+        assert!(!PartialOrd::gt(&a, &b));
+        assert!(PartialOrd::lt(&smaller, &larger));
+        assert!(!PartialOrd::lt(&larger, &smaller));
+        assert!(PartialOrd::gt(&larger, &smaller));
+        assert!(!PartialOrd::gt(&smaller, &larger));
+    }
+
+    #[test]
     fn test_debug_formatting() {
         let uncertain = Uncertain::new(|| 42);
         let debug_str = format!("{uncertain:?}");
@@ -618,10 +668,22 @@ mod tests {
     }
 
     #[test]
+    fn test_gt_method_boundary() {
+        let value = Uncertain::new(|| 60.0);
+        assert!(!value.gt(60.0).sample()); // 60 is not > 60
+    }
+
+    #[test]
     fn test_lt_method_api() {
         let temperature = Uncertain::new(|| -5.0);
         let freezing_evidence = temperature.lt(0.0);
         assert!(freezing_evidence.sample()); // -5 < 0
+    }
+
+    #[test]
+    fn test_lt_method_boundary() {
+        let value = Uncertain::new(|| 0.0);
+        assert!(!value.lt(0.0).sample()); // 0 is not < 0
     }
 
     #[test]
@@ -665,5 +727,31 @@ mod tests {
         let high_speed = Uncertain::point(70.0);
         let high_speed_evidence = high_speed.gt(60.0);
         assert!(high_speed_evidence.probability_exceeds(0.95));
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_take_samples_par_returns_requested_length_and_real_data() {
+        let uniform = Uncertain::uniform(0.0, 100.0).unwrap();
+        let samples = uniform.take_samples_par(500);
+        assert_eq!(samples.len(), 500);
+        assert!(!samples.iter().all(|&x| x == 0.0));
+        assert!(!samples.iter().all(|&x| x == 1.0));
+        assert!(!samples.iter().all(|&x| x == -1.0));
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        assert!((10.0..90.0).contains(&mean));
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_take_samples_cached_par_returns_requested_length_and_real_data() {
+        let uniform = Uncertain::uniform(0.0, 100.0).unwrap();
+        let samples = uniform.take_samples_cached_par(500);
+        assert_eq!(samples.len(), 500);
+        assert!(!samples.iter().all(|&x| x == 0.0));
+        assert!(!samples.iter().all(|&x| x == 1.0));
+        assert!(!samples.iter().all(|&x| x == -1.0));
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        assert!((10.0..90.0).contains(&mean));
     }
 }


### PR DESCRIPTION
## Summary

A full `cargo mutants` run found 339 surviving mutants across the crate — existing tests mostly checked loose properties ("in range", "mean within a wide tolerance") that don't distinguish an arithmetic operator swap or comparison-boundary flip from correct code. Added tests to close 273 of them; the remaining 66 are documented, not silently dropped.

**Final state:** 1370 mutants tested, 66 missed (down from 339), 843 caught, 439 unviable, 22 timeouts.

| File | Remaining | Why |
|---|---|---|
| `src/distributions.rs` | 21 | 2 proven equivalent mutants (Box-Muller's `z0` is symmetric about 0, so `mean + std*z0` and `mean - std*z0` are the same distribution); rest are unreachable exact-float boundaries or a ~3-4% variance shift in the gamma sampler indistinguishable from sampling noise without a seeded RNG (future spec) |
| `src/cache.rs` | 16 | global TTL singletons hardcoded to 300s (can't test expiry without a 300s sleep); `println!`-only functions with no return value |
| `src/computation.rs` | 12 | all in `GraphVisualizer::print_tree`/`GraphProfiler::print_report` — same println-only-no-return-value shape |
| `src/statistics.rs` | 8 | algebraically proven equivalent (e.g. `correlation`'s `-` vs `+` are exactly equal because `sum(y - mean_y) == 0` by definition of the mean) |
| `src/operations/arithmetic.rs` | 5 | `Arithmetic::zero()` for f64/f32/i32/i64/u32 literally equals `Default::default()` — true equivalent mutant, no possible distinguishing test |
| `src/hypothesis.rs` | 4 | proven equivalent — value already clamped to a tighter range earlier, so the mutated bound never binds |

Also fixed a mutation-testing config bug: `.cargo-mutants.toml`/`justfile` weren't running with `--all-features`, so every `#[cfg(feature = "parallel")]`-gated mutant (and its guarding test) wasn't even compiled — reported as MISSED regardless of test quality, since an uncompiled mutation is a no-op. `just mutants`/`just dev-mutants-diff` now pass `--all-features`.

No production code changed, only test code added/strengthened.

## Test plan

- [x] `just dev` green (fmt, clippy, tests default + parallel, doc tests, audit, deny, crap regression gate)
- [x] Full `cargo mutants --all-features --jobs 4` run: 66 missed / 1370 (down from 339), all remaining documented as equivalent mutants or genuinely untestable side-effect-only functions
- [x] `crap_baseline.json` updated (0 regressed, 44 improved from the new coverage)