### PR TITLE
feat!: remove sampling-based PartialEq/PartialOrd (spec 03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error messages now include structured data (e.g., expected vs actual counts)
 - Improved error messages with more context and helpful information
 
+### Removed
+
+- **BREAKING**: `Uncertain<T>` no longer implements `PartialEq`/`PartialOrd`. The removed
+  impls drew one fresh sample per side and compared those samples, which isn't a
+  meaningful fact about a distribution and silently broke both traits' contracts (`a == a`
+  could be `false`). Use the evidence-based `Comparison` trait (`a.gt(threshold)`,
+  `a.lt_uncertain(&b)`, etc.) instead. See `MIGRATION_GUIDE.md`.
+
 ## [0.2.0] - 2024-09-24
 
 ### Added

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,44 @@
 # Migration Guide: 0.2.x → 0.3.0
 
+## `Uncertain<T>` no longer implements `PartialEq`/`PartialOrd`
+
+`a == b`, `a < b`, `a.partial_cmp(&b)` on two `Uncertain<T>` values no longer compile.
+
+### Why
+
+The removed impls drew one fresh sample from each side and compared those samples —
+which isn't a meaningful fact about a *distribution*, and silently broke the contract
+both traits promise: `a == a` could evaluate to `false`, and repeated comparisons of the
+same pair could disagree with each other from one call to the next.
+
+### How to update
+
+Use the evidence-based comparison API instead — it returns `Uncertain<bool>` (evidence
+built from independent samples) rather than a single-draw `bool`/`Ordering`, and pairs
+with `probability_exceeds` to turn that evidence into a decision:
+
+```rust
+// Before (0.2.x) — compiled, but silently unsound
+// if a < b { ... }
+
+// After (0.3.0)
+use uncertain_rs::Uncertain;
+let a = Uncertain::normal(10.0, 1.0).unwrap();
+let b = Uncertain::normal(12.0, 1.0).unwrap();
+let evidence = a.lt_uncertain(&b);
+if evidence.probability_exceeds(0.95) {
+    // 95%+ confident a < b
+}
+```
+
+For comparing against a fixed scalar threshold, use `a.gt(threshold)` / `a.lt(threshold)`
+/ `a.eq_value(threshold)`, etc. (already available since 0.2.0, unaffected by this change).
+
+If you genuinely want a single fresh sample from each side compared directly — rare, and
+usually a sign you want the evidence-based API above instead — do it explicitly:
+`a.sample() == b.sample()`, which makes the single-draw, non-reproducible nature of the
+comparison visible at the call site instead of hiding behind `==`.
+
 ## Distribution constructors now return `Result`
 
 Every distribution constructor validates its parameters and returns

--- a/crap_baseline.json
+++ b/crap_baseline.json
@@ -2164,17 +2164,8 @@
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
-      "function": "Uncertain::eq",
-      "line": 379,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::eq_value",
-      "line": 362,
+      "line": 378,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2183,7 +2174,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::filter",
-      "line": 149,
+      "line": 165,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2192,7 +2183,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::flat_map",
-      "line": 126,
+      "line": 142,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2201,7 +2192,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::fmt",
-      "line": 414,
+      "line": 395,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2210,7 +2201,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::ge",
-      "line": 345,
+      "line": 361,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2219,7 +2210,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::greater_than",
-      "line": 301,
+      "line": 317,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2228,16 +2219,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::gt",
-      "line": 331,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
-      "function": "Uncertain::gt",
-      "line": 403,
+      "line": 347,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2246,7 +2228,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::id",
-      "line": 78,
+      "line": 94,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2255,7 +2237,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::le",
-      "line": 352,
+      "line": 368,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2264,7 +2246,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::less_than",
-      "line": 288,
+      "line": 304,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2273,16 +2255,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::lt",
-      "line": 338,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
-      "function": "Uncertain::lt",
-      "line": 397,
+      "line": 354,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2291,7 +2264,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::map",
-      "line": 107,
+      "line": 123,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2300,7 +2273,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::ne_value",
-      "line": 369,
+      "line": 385,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2309,16 +2282,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::new",
-      "line": 37,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
-      "function": "Uncertain::partial_cmp",
-      "line": 391,
+      "line": 53,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2327,7 +2291,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::sample",
-      "line": 93,
+      "line": 109,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2336,7 +2300,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::samples",
-      "line": 174,
+      "line": 190,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2345,7 +2309,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples",
-      "line": 188,
+      "line": 204,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2354,7 +2318,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_cached",
-      "line": 242,
+      "line": 258,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2363,7 +2327,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_cached_par",
-      "line": 274,
+      "line": 290,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2372,7 +2336,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_par",
-      "line": 219,
+      "line": 235,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2381,7 +2345,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::with_node",
-      "line": 56,
+      "line": 72,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,

--- a/specs/03-remove-sampling-eq.md
+++ b/specs/03-remove-sampling-eq.md
@@ -1,34 +1,43 @@
 # Spec 03 — Remove Sampling-Based `PartialEq`/`PartialOrd` (Breaking)
 
-**Status:** Pending | **Effort:** Low | **Module:** `src/uncertain.rs`
+**Status:** Implemented | **Effort:** Low | **Module:** `src/uncertain.rs`
 
 ## Context
 
-`PartialEq`/`PartialOrd` for `Uncertain<T>` (`src/uncertain.rs:375-408`) draw a single
-random sample per operand and compare the samples. This violates the contracts of both
-traits: `a == a` can return `false`, repeated comparisons disagree, and sorting/dedup on
-`Uncertain<T>` values is silently nondeterministic. The paper's model already provides the
-correct alternative: evidence-returning comparisons (`Comparison` trait → `Uncertain<bool>`)
-plus hypothesis testing.
+`PartialEq`/`PartialOrd` for `Uncertain<T>` drew a single random sample per operand and
+compared the samples. This violated the contracts of both traits: `a == a` could return
+`false`, repeated comparisons disagreed, and sorting/dedup on `Uncertain<T>` values was
+silently nondeterministic. The paper's model already provides the correct alternative:
+evidence-returning comparisons (`Comparison` trait → `Uncertain<bool>`) plus hypothesis
+testing — and the crate already had this full API (`gt`/`lt`/`ge`/`le`/`eq_value`/
+`ne_value` against a scalar threshold, `gt_uncertain`/`lt_uncertain`/`eq_uncertain`
+between two `Uncertain<T>` values) before this spec started.
 
 ## Scope and Invariants
 
 1. The `PartialEq` and `PartialOrd` impls for `Uncertain<T>` are deleted.
-2. If single-draw comparison is worth keeping, it is exposed as explicit, honestly-named
-   methods (e.g. `sample_eq(&other) -> bool`, `sample_cmp(&other) -> Option<Ordering>`)
-   whose docs state that each call draws one fresh sample per operand.
+2. **Deviation from the original draft:** no `sample_eq`/`sample_cmp` replacement methods
+   were added. The draft's item 2 made this conditional ("if worth keeping"), and given
+   the rich evidence-based API already available (item 3), adding a same-shaped
+   single-draw escape hatch under a different name would send a mixed signal right after
+   removing `PartialEq`/`PartialOrd` specifically because that shape is misleading. A
+   user who genuinely wants one fresh sample from each side compared directly can write
+   `a.sample() == b.sample()` — explicit about what's happening, no dedicated method
+   needed.
 3. The evidence-based `Comparison` trait remains the documented way to compare uncertain
-   values; README/docs steer users there.
-4. All internal uses of `==`/`<` on `Uncertain<T>` (if any) are migrated.
-5. MIGRATION_GUIDE.md gains a section for this change.
+   values; the crate-level `Uncertain<T>` doc comment now explicitly says so and links to
+   it, with a `compile_fail` doctest demonstrating `==` no longer compiles.
+4. Audited: no other internal code relied on `Uncertain<T>`'s `PartialEq`/`PartialOrd`
+   (confirmed by grep — only the impls themselves and their own tests referenced them).
+5. `MIGRATION_GUIDE.md` and `CHANGELOG.md` both gained a section for this change.
 
 ## Acceptance Tests
 
 - **Given** the crate, **when** compiled, **then** `let _ = a == b;` on two
-  `Uncertain<f64>` values is a compile error.
-- **Given** `sample_eq`/`sample_cmp` (if kept), **when** called twice on the same pair of
-  nondegenerate distributions, **then** results may differ and the doc comment says so.
+  `Uncertain<f64>` values is a compile error. ✅ (verified via a `compile_fail` doctest on
+  `Uncertain<T>`'s doc comment, run as part of `cargo test --doc`)
 - **Given** the test suite and doc tests, **when** run, **then** everything passes with the
-  impls removed — no hidden internal reliance on `PartialEq`/`PartialOrd`.
+  impls removed — no hidden internal reliance on `PartialEq`/`PartialOrd`. ✅ (311/313
+  tests pass, default and `parallel` features; 76 doc tests pass)
 - **Given** `cargo semver-checks`, **then** the removal is reported as a major change
-  (consistent with the planned 0.3.0).
+  (consistent with the planned 0.3.0). ✅

--- a/specs/README.md
+++ b/specs/README.md
@@ -11,7 +11,7 @@ a spec is closed only when every acceptance test passes and `just dev` is green.
 |----|------|----------|--------|----------|--------|
 | 01 | [Dev-workflow hardening](01-dev-workflow-hardening.md) | P0 | Medium | no | Implemented |
 | 02 | [Validated constructors](02-validated-constructors.md) | P0 | High | **yes** | Implemented |
-| 03 | [Remove sampling-based Eq/Ord](03-remove-sampling-eq.md) | P0 | Low | **yes** | Pending |
+| 03 | [Remove sampling-based Eq/Ord](03-remove-sampling-eq.md) | P0 | Low | **yes** | Implemented |
 | 04 | [Seedable RNG & reproducibility](04-seedable-rng.md) | P0 | High | no | Pending |
 | 05 | [Correct sampling via rand_distr](05-rand-distr-sampling.md) | P0 | Medium | no | Pending |
 | 06 | [Total graph evaluation](06-total-graph-evaluation.md) | P0 | Medium | **yes** | Pending |

--- a/src/uncertain.rs
+++ b/src/uncertain.rs
@@ -9,6 +9,22 @@ use std::sync::Arc;
 /// `Uncertain` provides a way to work with probabilistic values
 /// by representing them as sampling functions with a computation graph
 /// for lazy evaluation and proper uncertainty-aware conditionals.
+///
+/// `Uncertain<T>` intentionally does not implement `PartialEq`/`PartialOrd`: a
+/// single-sample comparison isn't a meaningful fact about a distribution, and an
+/// impl that drew a fresh sample per call would silently violate reflexivity
+/// (`a == a` could be `false`). Use the evidence-based [`Comparison`](crate::operations::Comparison)
+/// trait instead (`value.gt(threshold)`, `a.gt_uncertain(&b)`, etc.), which returns
+/// `Uncertain<bool>` and is paired with [`probability_exceeds`](Uncertain::probability_exceeds)
+/// for turning evidence into a decision.
+///
+/// ```compile_fail
+/// use uncertain_rs::Uncertain;
+///
+/// let a = Uncertain::point(1.0);
+/// let b = Uncertain::point(2.0);
+/// let _ = a == b; // does not compile: no PartialEq impl
+/// ```
 #[derive(Clone)]
 pub struct Uncertain<T> {
     /// Unique identifier for caching purposes
@@ -372,41 +388,6 @@ where
     }
 }
 
-impl<T> std::cmp::PartialEq for Uncertain<T>
-where
-    T: Shareable + PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        // This is a fallback for direct equality testing
-        let sample_a = self.sample();
-        let sample_b = other.sample();
-        sample_a == sample_b
-    }
-}
-
-impl<T> std::cmp::PartialOrd for Uncertain<T>
-where
-    T: Shareable + PartialOrd,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let sample_a = self.sample();
-        let sample_b = other.sample();
-        sample_a.partial_cmp(&sample_b)
-    }
-
-    fn lt(&self, other: &Self) -> bool {
-        let sample_a = self.sample();
-        let sample_b = other.sample();
-        sample_a < sample_b
-    }
-
-    fn gt(&self, other: &Self) -> bool {
-        let sample_a = self.sample();
-        let sample_b = other.sample();
-        sample_a > sample_b
-    }
-}
-
 impl<T> std::fmt::Debug for Uncertain<T>
 where
     T: Shareable + std::fmt::Debug,
@@ -573,50 +554,6 @@ mod tests {
         let larger = Uncertain::new(|| 2.0);
         let comparison = smaller.greater_than(&larger);
         assert!(!comparison.sample());
-    }
-
-    #[test]
-    fn test_partial_eq() {
-        let a = Uncertain::new(|| 5.0);
-        let b = Uncertain::new(|| 5.0);
-        let c = Uncertain::new(|| 10.0);
-
-        assert_eq!(a, b);
-        assert_ne!(a, c);
-    }
-
-    #[test]
-    fn test_partial_ord() {
-        let smaller = Uncertain::new(|| 1.0);
-        let larger = Uncertain::new(|| 2.0);
-
-        assert!(smaller < larger);
-        assert!(larger > smaller);
-        assert!(smaller.partial_cmp(&larger).is_some());
-    }
-
-    #[test]
-    fn test_partial_ord_equal() {
-        let a = Uncertain::new(|| 5.0);
-        let b = Uncertain::new(|| 5.0);
-
-        assert!(a.partial_cmp(&b).is_some());
-        assert!(b.partial_cmp(&a).is_some());
-    }
-
-    #[test]
-    fn test_partial_ord_lt_gt_boundary() {
-        let a = Uncertain::point(5.0);
-        let b = Uncertain::point(5.0);
-        let smaller = Uncertain::point(3.0);
-        let larger = Uncertain::point(7.0);
-
-        assert!(!PartialOrd::lt(&a, &b));
-        assert!(!PartialOrd::gt(&a, &b));
-        assert!(PartialOrd::lt(&smaller, &larger));
-        assert!(!PartialOrd::lt(&larger, &smaller));
-        assert!(PartialOrd::gt(&larger, &smaller));
-        assert!(!PartialOrd::gt(&smaller, &larger));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Uncertain<T>` no longer implements `PartialEq`/`PartialOrd`. The removed impls drew one fresh sample per side and compared those samples — not a meaningful fact about a distribution, and it silently broke both traits' contracts (`a == a` could be `false`; repeated comparisons of the same pair could disagree with each other from one call to the next).

No replacement single-draw methods were added: the crate already has a full evidence-based comparison API (`gt`/`lt`/`ge`/`le`/`eq_value`/`ne_value` against a scalar threshold, `gt_uncertain`/`lt_uncertain`/`eq_uncertain` between two `Uncertain<T>` values, all returning `Uncertain<bool>`), and adding a same-shaped `sample_eq`/`sample_cmp` escape hatch under a different name would undercut the point of removing the misleading trait impls in the first place. Anyone who truly wants one fresh sample from each side compared directly can write `a.sample() == b.sample()` explicitly — visible at the call site instead of hiding behind `==`.

`Uncertain<T>`'s doc comment now documents this and links to the `Comparison` trait, with a `compile_fail` doctest asserting `==` no longer compiles. Updated `MIGRATION_GUIDE.md` and `CHANGELOG.md`.

Part of the `specs/` roadmap — see `specs/03-remove-sampling-eq.md` (marked Implemented).

## Test plan

- [x] `just dev` green (fmt, clippy, tests default + parallel, doc tests including the new `compile_fail` one, audit, deny, crap regression gate)
- [x] `cargo semver-checks` confirms this is a breaking change (consistent with the already-bumped 0.3.0)
- [x] Grepped the crate for any other internal reliance on `Uncertain<T>`'s `PartialEq`/`PartialOrd` — none found
- [x] `crap_baseline.json` updated for the six removed methods