### PR TITLE
feat!: total graph evaluation with Result-returning error handling (spec 06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across runs and platforms for the same seed; `take_samples_with_par` (parallel
   feature) gives the same guarantee independent of thread count. `sample()`/
   `take_samples()` are unchanged (still thread-local randomness).
+- `UncertainError::UnsupportedNode` - returned by `ComputationNode` evaluation methods
+  when a graph node isn't evaluable in the requested domain (e.g. a boolean `BinaryOp`,
+  for which no operation is defined).
 
 ### Changed
 
@@ -62,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `lambda > ~1.844e19` (`Poisson::MAX_LAMBDA`, a real limit of the sampling algorithm) —
   see `MIGRATION_GUIDE.md`. No other observable behavior change; degenerate cases
   (`std_dev`/`scale`/`lambda` of `0`) are still supported exactly as before.
+- **BREAKING**: `ComputationNode::evaluate`, `evaluate_arithmetic`, and `evaluate_bool` now
+  return `Result<_, UncertainError>` instead of panicking on unsupported node/domain
+  combinations (e.g. a `BinaryOp` passed to `evaluate`, or a boolean `BinaryOp` passed to
+  `evaluate_bool`). `evaluate_arithmetic` additionally now handles `Conditional` nodes
+  directly (it absorbs the former `evaluate_conditional_with_arithmetic`, which is removed).
+  `evaluate_fresh` keeps its infallible `-> T` signature. See `MIGRATION_GUIDE.md`.
 
 ### Removed
 
@@ -70,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   meaningful fact about a distribution and silently broke both traits' contracts (`a == a`
   could be `false`). Use the evidence-based `Comparison` trait (`a.gt(threshold)`,
   `a.lt_uncertain(&b)`, etc.) instead. See `MIGRATION_GUIDE.md`.
+- **BREAKING**: `ComputationNode::evaluate_conditional_with_arithmetic` is removed; its
+  logic is now part of `evaluate_arithmetic` (see above).
 
 ## [0.2.0] - 2024-09-24
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -192,3 +192,42 @@ return `Result`, same as the `Uncertain` variants.
 
 Valid inputs are unaffected: every `Ok(...)` value is bit-identical to the corresponding
 0.2.x return value.
+
+## `ComputationNode` evaluation methods now return `Result` instead of panicking
+
+`ComputationNode::evaluate`, `evaluate_arithmetic`, and `evaluate_bool` (low-level graph
+evaluation, not part of the typical `Uncertain<T>` usage surface) return
+`Result<_, UncertainError>` instead of panicking on node shapes they can't handle.
+
+### Why
+
+Each of these three methods is total over some, but not all, `ComputationNode` variants —
+which variants depends on `T`'s trait bounds at each method (see below). Before 0.3.0, the
+unsupported cases were a `panic!`; a library consumer walking a graph and picking the wrong
+method for a node shape could crash instead of getting a typed, recoverable error.
+
+### How to update
+
+If you call these methods directly (most code doesn't — `Uncertain<T>`'s combinator API
+builds and evaluates graphs internally and is unaffected), handle the `Result`:
+
+```rust
+// Before (0.2.x) — panicked on a BinaryOp node
+// let value = node.evaluate(&mut context);
+
+// After (0.3.0)
+let value = node.evaluate(&mut context)?;
+```
+
+- `evaluate` (`T: Shareable`) is total for `Leaf`/`UnaryOp`; `BinaryOp`/`Conditional` return
+  `Err(UnsupportedNode)` — this is a structural limit (both require trait bounds `Shareable`
+  alone doesn't provide), not a temporary gap.
+- `evaluate_arithmetic` (`T: Arithmetic`) is now the total dispatcher for the arithmetic
+  domain, including `Conditional` (it absorbs the former
+  `evaluate_conditional_with_arithmetic`, which is removed — call `evaluate_arithmetic`
+  instead).
+- `evaluate_bool` is total except for `BinaryOp`, which has no defined `bool` operation.
+- `evaluate_fresh` is unaffected: it keeps its infallible `-> T` signature.
+
+`GraphProfiler::get_stats` is unaffected by this section — it already returned `Option` and
+no longer has an internal (unreachable) `.expect()`.

--- a/crap_baseline.json
+++ b/crap_baseline.json
@@ -356,7 +356,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "AdaptiveSampling::default",
-      "line": 20,
+      "line": 21,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -365,7 +365,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::binary_op",
-      "line": 306,
+      "line": 321,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -374,7 +374,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::compute_complexity",
-      "line": 390,
+      "line": 405,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0,
@@ -383,7 +383,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::conditional",
-      "line": 331,
+      "line": 346,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -392,7 +392,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::depth",
-      "line": 362,
+      "line": 377,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0,
@@ -401,43 +401,34 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::evaluate",
-      "line": 189,
-      "cyclomatic": 8.0,
-      "coverage": 93.75,
-      "crap": 8.015625,
+      "line": 191,
+      "cyclomatic": 9.0,
+      "coverage": 100.0,
+      "crap": 9.0,
       "crate": "uncertain-rs"
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::evaluate_arithmetic",
-      "line": 235,
-      "cyclomatic": 8.0,
-      "coverage": 95.65217391304348,
-      "crap": 8.005260129859456,
+      "line": 240,
+      "cyclomatic": 13.0,
+      "coverage": 100.0,
+      "crap": 13.0,
       "crate": "uncertain-rs"
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::evaluate_bool",
-      "line": 463,
-      "cyclomatic": 9.0,
-      "coverage": 86.36363636363636,
-      "crap": 9.20539068369647,
-      "crate": "uncertain-rs"
-    },
-    {
-      "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
-      "function": "ComputationNode::evaluate_conditional_with_arithmetic",
-      "line": 506,
-      "cyclomatic": 4.0,
+      "line": 480,
+      "cyclomatic": 11.0,
       "coverage": 100.0,
-      "crap": 4.0,
+      "crap": 11.0,
       "crate": "uncertain-rs"
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::evaluate_fresh",
-      "line": 285,
+      "line": 299,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -446,7 +437,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::has_conditionals",
-      "line": 377,
+      "line": 392,
       "cyclomatic": 6.0,
       "coverage": 100.0,
       "crap": 6.0,
@@ -455,7 +446,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::hash_structure",
-      "line": 420,
+      "line": 435,
       "cyclomatic": 5.0,
       "coverage": 55.172413793103445,
       "crap": 7.252039854032556,
@@ -464,7 +455,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::leaf",
-      "line": 294,
+      "line": 309,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -473,7 +464,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::map",
-      "line": 319,
+      "line": 334,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -482,7 +473,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::node_count",
-      "line": 345,
+      "line": 360,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0,
@@ -491,7 +482,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "ComputationNode::structural_hash",
-      "line": 411,
+      "line": 426,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -500,7 +491,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::check_addition_identities",
-      "line": 685,
+      "line": 674,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0,
@@ -509,7 +500,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::check_division_identities",
-      "line": 809,
+      "line": 798,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -518,7 +509,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::check_multiplication_identities",
-      "line": 744,
+      "line": 733,
       "cyclomatic": 9.0,
       "coverage": 100.0,
       "crap": 9.0,
@@ -527,7 +518,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::check_subtraction_identities",
-      "line": 721,
+      "line": 710,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -536,7 +527,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding",
-      "line": 923,
+      "line": 912,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0,
@@ -545,7 +536,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding_binary_op",
-      "line": 946,
+      "line": 935,
       "cyclomatic": 8.0,
       "coverage": 79.3103448275862,
       "crap": 8.56681290745828,
@@ -554,7 +545,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding_bool",
-      "line": 1053,
+      "line": 1042,
       "cyclomatic": 4.0,
       "coverage": 40.0,
       "crap": 7.4559999999999995,
@@ -563,7 +554,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding_bool_conditional",
-      "line": 1095,
+      "line": 1084,
       "cyclomatic": 4.0,
       "coverage": 0.0,
       "crap": 20.0,
@@ -572,7 +563,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding_bool_unary_op",
-      "line": 1068,
+      "line": 1057,
       "cyclomatic": 5.0,
       "coverage": 0.0,
       "crap": 30.0,
@@ -581,7 +572,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding_conditional",
-      "line": 1019,
+      "line": 1008,
       "cyclomatic": 4.0,
       "coverage": 76.0,
       "crap": 4.221184,
@@ -590,7 +581,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::constant_folding_unary_op",
-      "line": 989,
+      "line": 978,
       "cyclomatic": 5.0,
       "coverage": 71.42857142857143,
       "crap": 5.5830903790087465,
@@ -599,7 +590,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::default",
-      "line": 1153,
+      "line": 1142,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0,
@@ -608,7 +599,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::eliminate_common_subexpressions",
-      "line": 555,
+      "line": 544,
       "cyclomatic": 7.0,
       "coverage": 61.36363636363637,
       "crap": 9.82608236288505,
@@ -617,7 +608,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::eliminate_identity_operations",
-      "line": 619,
+      "line": 608,
       "cyclomatic": 5.0,
       "coverage": 62.5,
       "crap": 6.318359375,
@@ -626,7 +617,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::eliminate_identity_operations_binary",
-      "line": 642,
+      "line": 631,
       "cyclomatic": 9.0,
       "coverage": 89.28571428571429,
       "crap": 9.099626457725947,
@@ -635,7 +626,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::eliminate_identity_operations_bool",
-      "line": 867,
+      "line": 856,
       "cyclomatic": 4.0,
       "coverage": 0.0,
       "crap": 20.0,
@@ -644,7 +635,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::eliminate_identity_operations_conditional",
-      "line": 847,
+      "line": 836,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0,
@@ -653,7 +644,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::eliminate_identity_operations_unary",
-      "line": 832,
+      "line": 821,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0,
@@ -662,7 +653,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::is_constant",
-      "line": 1125,
+      "line": 1114,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -671,7 +662,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::is_constant_bool",
-      "line": 1140,
+      "line": 1129,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -680,7 +671,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::is_constant_one",
-      "line": 909,
+      "line": 898,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -689,7 +680,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::is_constant_zero",
-      "line": 895,
+      "line": 884,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -698,7 +689,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::new",
-      "line": 537,
+      "line": 526,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -707,7 +698,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphOptimizer::optimize",
-      "line": 545,
+      "line": 534,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -716,7 +707,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphProfiler::default",
-      "line": 1364,
+      "line": 1344,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -725,16 +716,16 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphProfiler::get_stats",
-      "line": 1316,
+      "line": 1300,
       "cyclomatic": 3.0,
-      "coverage": 96.15384615384616,
-      "crap": 3.0005120619025942,
+      "coverage": 95.45454545454545,
+      "crap": 3.000845229151014,
       "crate": "uncertain-rs"
     },
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphProfiler::new",
-      "line": 1286,
+      "line": 1275,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -743,7 +734,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphProfiler::print_report",
-      "line": 1347,
+      "line": 1327,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0,
@@ -752,7 +743,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphProfiler::profile_execution",
-      "line": 1293,
+      "line": 1282,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -761,7 +752,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphVisualizer::add_node_to_dot",
-      "line": 1175,
+      "line": 1164,
       "cyclomatic": 9.0,
       "coverage": 93.02325581395348,
       "crap": 9.02750701196121,
@@ -770,7 +761,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphVisualizer::print_tree",
-      "line": 1232,
+      "line": 1221,
       "cyclomatic": 9.0,
       "coverage": 47.22222222222222,
       "crap": 20.907986111111114,
@@ -779,7 +770,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "GraphVisualizer::to_dot",
-      "line": 1164,
+      "line": 1153,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -788,7 +779,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::adaptive_sampling",
-      "line": 119,
+      "line": 120,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -797,7 +788,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::clear",
-      "line": 85,
+      "line": 86,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -806,7 +797,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::default",
-      "line": 130,
+      "line": 131,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -815,7 +806,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::get_value",
-      "line": 75,
+      "line": 76,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0,
@@ -824,7 +815,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::is_empty",
-      "line": 97,
+      "line": 98,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -833,7 +824,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::len",
-      "line": 91,
+      "line": 92,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -842,7 +833,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::new",
-      "line": 55,
+      "line": 56,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -851,7 +842,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::set_adaptive_sampling",
-      "line": 124,
+      "line": 125,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -860,7 +851,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::set_value",
-      "line": 80,
+      "line": 81,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -869,7 +860,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::should_cache_node",
-      "line": 103,
+      "line": 104,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0,
@@ -878,7 +869,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/computation.rs",
       "function": "SampleContext::with_caching_strategy",
-      "line": 65,
+      "line": 66,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1076,7 +1067,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::invalid_bandwidth",
-      "line": 215,
+      "line": 226,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1085,7 +1076,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::invalid_confidence",
-      "line": 201,
+      "line": 212,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1094,7 +1085,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::invalid_parameter",
-      "line": 108,
+      "line": 119,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1103,7 +1094,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::invalid_quantile",
-      "line": 187,
+      "line": 198,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1112,7 +1103,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::invalid_sample_count",
-      "line": 173,
+      "line": 184,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1121,7 +1112,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::invalid_weights",
-      "line": 157,
+      "line": 168,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1130,7 +1121,16 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::non_finite",
-      "line": 130,
+      "line": 141,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0,
+      "crate": "uncertain-rs"
+    },
+    {
+      "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
+      "function": "UncertainError::unsupported_node",
+      "line": 241,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -1139,7 +1139,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/error.rs",
       "function": "UncertainError::weight_mismatch",
-      "line": 144,
+      "line": 155,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2246,7 +2246,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::eq_value",
-      "line": 468,
+      "line": 470,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2255,7 +2255,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::filter",
-      "line": 191,
+      "line": 193,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2264,7 +2264,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::flat_map",
-      "line": 168,
+      "line": 170,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2273,7 +2273,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::fmt",
-      "line": 485,
+      "line": 487,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2282,7 +2282,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::ge",
-      "line": 451,
+      "line": 453,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2291,7 +2291,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::greater_than",
-      "line": 407,
+      "line": 409,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2300,7 +2300,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::gt",
-      "line": 437,
+      "line": 439,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2309,7 +2309,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::id",
-      "line": 95,
+      "line": 97,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2318,7 +2318,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::le",
-      "line": 458,
+      "line": 460,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2327,7 +2327,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::less_than",
-      "line": 394,
+      "line": 396,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2336,7 +2336,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::lt",
-      "line": 444,
+      "line": 446,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2345,7 +2345,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::map",
-      "line": 149,
+      "line": 151,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2354,7 +2354,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::ne_value",
-      "line": 475,
+      "line": 477,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2372,7 +2372,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::sample",
-      "line": 110,
+      "line": 112,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2381,7 +2381,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::sample_with",
-      "line": 133,
+      "line": 135,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2390,7 +2390,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::samples",
-      "line": 216,
+      "line": 218,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2399,7 +2399,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples",
-      "line": 230,
+      "line": 232,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2408,7 +2408,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_cached",
-      "line": 348,
+      "line": 350,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2417,7 +2417,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_cached_par",
-      "line": 380,
+      "line": 382,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2426,7 +2426,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_par",
-      "line": 288,
+      "line": 290,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2435,7 +2435,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_with",
-      "line": 254,
+      "line": 256,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,
@@ -2444,7 +2444,7 @@
     {
       "file": "/Users/mnkn/GitHub/uncertain-rs/src/uncertain.rs",
       "function": "Uncertain::take_samples_with_par",
-      "line": 318,
+      "line": 320,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0,

--- a/specs/06-total-graph-evaluation.md
+++ b/specs/06-total-graph-evaluation.md
@@ -1,6 +1,6 @@
 # Spec 06 — Total Graph Evaluation (Breaking)
 
-**Status:** Pending | **Effort:** Medium | **Module:** `src/computation.rs`
+**Status:** Implemented | **Effort:** Medium | **Module:** `src/computation.rs`
 
 ## Context
 
@@ -42,3 +42,46 @@ method for a node shape. `GraphProfiler::get_stats` also uses `.expect`
   throughput is within noise (no boxing/indirection regressions).
 - **Given** the full test suite, **then** all previous `#[should_panic]` evaluation tests
   are replaced and green as error-variant assertions.
+
+## Implementation notes (deviations from the draft above)
+
+- **One dispatcher per domain, not one dispatcher overall.** `evaluate`, `evaluate_arithmetic`,
+  and `evaluate_bool` all now return `Result<_, UncertainError>` and none panics, but they
+  remain three separate methods rather than three thin wrappers over a single total
+  dispatch — there is no single dispatch to wrap them around, because each is total over a
+  *different* set of variants, dictated by `T`'s trait bounds:
+  - `evaluate` (`T: Shareable` only) is total for `Leaf`/`UnaryOp` and returns
+    `Err(UnsupportedNode)` for `BinaryOp`/`Conditional` — this is a structural limit, not a
+    gap: `BinaryOp` needs `T: Arithmetic` (`BinaryOperation::apply` has no meaning otherwise)
+    and `Conditional` needs to evaluate a `bool` condition, neither of which is available
+    under a bare `Shareable` bound.
+  - `evaluate_arithmetic` (`T: Arithmetic`) is the true total dispatcher for the arithmetic
+    domain: it now handles `Conditional` directly (evaluating the condition via
+    `evaluate_bool` and delegating to the taken branch), absorbing what used to be the
+    separate `evaluate_conditional_with_arithmetic` method, which is now deleted. Its lone
+    external caller (`Uncertain::with_node`'s `sample_fn`, `src/uncertain.rs`) calls
+    `evaluate_arithmetic(...).expect(...)` instead — documented as an internal invariant,
+    since graphs built through the public `Uncertain<T>` combinator API are always
+    well-formed and this path can't observe an `Err` in practice.
+  - `evaluate_bool` is total except for `BinaryOp`, which is genuinely unsupported: no
+    `BinaryOperation` variant is defined for `bool` (`BinaryOperation` is `Add/Sub/Mul/Div`,
+    and `Arithmetic` has no `bool` impl), so a boolean `BinaryOp` node can only arise from
+    directly misusing the low-level `ComputationNode` constructors.
+  - `evaluate_fresh` keeps its existing infallible signature (`-> T`, not `-> Result<T, _>`)
+    since it has ~20 pre-existing callers (mostly tests) that treat it as such; it now
+    calls `evaluate_arithmetic(...).expect(...)` internally, for the same well-formed-graph
+    reason as `with_node` above.
+- **CRAP regression, accepted and rebaselined.** `evaluate`, `evaluate_arithmetic`, and
+  `evaluate_bool` all show a higher CRAP score against the committed baseline (CC +1 to +5)
+  from the added `Result` plumbing and, for `evaluate_arithmetic`, the absorbed conditional
+  branch. All three reached 100% line coverage in the same change (new tests for the error
+  paths, the previously-uncovered `Map`/`Filter` arms of the raw `evaluate`/`evaluate_bool`
+  methods, and the bool-leaf memoization/false-branch/filter paths), so the remaining CRAP
+  increase is purely the higher cyclomatic complexity — not a coverage gap. `crap_baseline.json`
+  was regenerated (`just crap-update-baseline`) to accept this as intentional.
+- **Benchmarks.** `computation_graphs` criterion group (`benches/performance_benchmarks.rs`)
+  re-run after the change: `complex_expression_expected_value` and `complex_expression_variance`
+  within noise (small improvement, ~1-2%); `multiple_stats_operations` showed a one-off +7.7%
+  on a first run but reproduced as "within noise" (-0.8%) on a second run — the Result
+  wrapping is a zero-allocation enum tag on the `Ok` fast path, so no structural regression is
+  expected or observed.

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,7 @@ a spec is closed only when every acceptance test passes and `just dev` is green.
 | 03 | [Remove sampling-based Eq/Ord](03-remove-sampling-eq.md) | P0 | Low | **yes** | Implemented |
 | 04 | [Seedable RNG & reproducibility](04-seedable-rng.md) | P0 | High | no | Implemented |
 | 05 | [Correct sampling via rand_distr](05-rand-distr-sampling.md) | P0 | Medium | no | Implemented |
-| 06 | [Total graph evaluation](06-total-graph-evaluation.md) | P0 | Medium | **yes** | Pending |
+| 06 | [Total graph evaluation](06-total-graph-evaluation.md) | P0 | Medium | **yes** | Implemented |
 | 07 | [Sound constant folding](07-sound-constant-folding.md) | P0 | Medium | no | Pending |
 | 08 | [Effective CSE](08-effective-cse.md) | P1 | Medium | no | Pending |
 | 09 | [Consistent variance policy](09-variance-policy.md) | P1 | Low | behavioral | Pending |
@@ -47,12 +47,16 @@ a spec is closed only when every acceptance test passes and `just dev` is green.
    (`scale`/`lambda` of `0`), handled via special-casing before ever calling
    `rand_distr`; measured a 65.5% speedup for normal sampling.)*
 3. **02, 03, 06, 18** — the breaking API changes, batched into one 0.3.0 release.
-   *(02, 03, 18 implemented. 02's statistics-entry-point-validation half was split out to
+   *(All four implemented. 02's statistics-entry-point-validation half was split out to
    18 — see 02's spec for why: a comparably large, independently-shippable ripple through
-   a different module. 18 validates at construction time for `LazyStats`/
-   `AdaptiveLazyStats` (sample count fixed once, reused by every accessor) and at call
-   time everywhere else (sample count/quantile/confidence/bandwidth are genuine per-call
-   parameters) — see 18's spec for the full per-method breakdown.)*
+   a different module. 06 kept `evaluate`/`evaluate_arithmetic`/`evaluate_bool` as three
+   separate `Result`-returning dispatchers, one total per value domain, rather than one
+   dispatcher wrapped three ways — see 06's spec's implementation notes for why a single
+   dispatcher isn't meaningful across domains with different trait bounds. 18 validates
+   at construction time for `LazyStats`/`AdaptiveLazyStats` (sample count fixed once,
+   reused by every accessor) and at call time everywhere else (sample
+   count/quantile/confidence/bandwidth are genuine per-call parameters) — see 18's spec
+   for the full per-method breakdown.)*
 4. **07 → 08** — optimizer correctness before optimizer effectiveness.
 5. **09, 10, 11, 14, 15, 17, 19** in any order.
 6. **12, 13, 16** — feature/polish tail.

--- a/specs/README.md
+++ b/specs/README.md
@@ -7,37 +7,37 @@ a spec is closed only when every acceptance test passes and `just dev` is green.
 
 ## Index
 
-| #  | Spec | Priority | Effort | Breaking | Status |
-|----|------|----------|--------|----------|--------|
-| 01 | [Dev-workflow hardening](01-dev-workflow-hardening.md) | P0 | Medium | no | Implemented |
-| 02 | [Validated constructors](02-validated-constructors.md) | P0 | High | **yes** | Implemented |
-| 03 | [Remove sampling-based Eq/Ord](03-remove-sampling-eq.md) | P0 | Low | **yes** | Implemented |
-| 04 | [Seedable RNG & reproducibility](04-seedable-rng.md) | P0 | High | no | Implemented |
-| 05 | [Correct sampling via rand_distr](05-rand-distr-sampling.md) | P0 | Medium | no | Implemented |
-| 06 | [Total graph evaluation](06-total-graph-evaluation.md) | P0 | Medium | **yes** | Implemented |
-| 07 | [Sound constant folding](07-sound-constant-folding.md) | P0 | Medium | no | Pending |
-| 08 | [Effective CSE](08-effective-cse.md) | P1 | Medium | no | Pending |
-| 09 | [Consistent variance policy](09-variance-policy.md) | P1 | Low | behavioral | Pending |
-| 10 | [Bounded caches, no NaN paths](10-bounded-caches.md) | P1 | Medium | no | Partially implemented |
-| 11 | [Property-based testing](11-property-based-testing.md) | P1 | Medium | no | Pending |
-| 12 | [Serde support](12-serde-support.md) | P2 | Low | no | Pending |
-| 13 | [More distributions](13-more-distributions.md) | P2 | Medium | no | Pending |
-| 14 | [Benchmarks & coverage gates in CI](14-bench-regression-ci.md) | P1 | Medium | no | Pending |
-| 15 | [Docs & meta cleanup](15-docs-and-meta.md) | P1 | Low | no | Pending |
-| 16 | [Release automation](16-release-automation.md) | P2 | Low | no | Pending |
-| 17 | [Clippy pedantic/nursery cleanup](17-clippy-pedantic-cleanup.md) | P2 | Medium | no | Pending |
-| 18 | [Statistics entry-point validation](18-statistics-validation.md) | P0 | High | **yes** | Implemented |
-| 19 | [Deflake existing test suite](19-deflake-existing-tests.md) | P1 | High | no | Pending |
+| #   | Spec                                                             | Priority | Effort | Breaking   | Status                |
+| --- | ---------------------------------------------------------------- | -------- | ------ | ---------- | --------------------- |
+| 01  | [Dev-workflow hardening](01-dev-workflow-hardening.md)           | P0       | Medium | no         | Implemented           |
+| 02  | [Validated constructors](02-validated-constructors.md)           | P0       | High   | **yes**    | Implemented           |
+| 03  | [Remove sampling-based Eq/Ord](03-remove-sampling-eq.md)         | P0       | Low    | **yes**    | Implemented           |
+| 04  | [Seedable RNG & reproducibility](04-seedable-rng.md)             | P0       | High   | no         | Implemented           |
+| 05  | [Correct sampling via rand_distr](05-rand-distr-sampling.md)     | P0       | Medium | no         | Implemented           |
+| 06  | [Total graph evaluation](06-total-graph-evaluation.md)           | P0       | Medium | **yes**    | Implemented           |
+| 07  | [Sound constant folding](07-sound-constant-folding.md)           | P0       | Medium | no         | Pending               |
+| 08  | [Effective CSE](08-effective-cse.md)                             | P1       | Medium | no         | Pending               |
+| 09  | [Consistent variance policy](09-variance-policy.md)              | P1       | Low    | behavioral | Pending               |
+| 10  | [Bounded caches, no NaN paths](10-bounded-caches.md)             | P1       | Medium | no         | Partially implemented |
+| 11  | [Property-based testing](11-property-based-testing.md)           | P1       | Medium | no         | Pending               |
+| 12  | [Serde support](12-serde-support.md)                             | P2       | Low    | no         | Pending               |
+| 13  | [More distributions](13-more-distributions.md)                   | P2       | Medium | no         | Pending               |
+| 14  | [Benchmarks & coverage gates in CI](14-bench-regression-ci.md)   | P1       | Medium | no         | Pending               |
+| 15  | [Docs & meta cleanup](15-docs-and-meta.md)                       | P1       | Low    | no         | Pending               |
+| 16  | [Release automation](16-release-automation.md)                   | P2       | Low    | no         | Pending               |
+| 17  | [Clippy pedantic/nursery cleanup](17-clippy-pedantic-cleanup.md) | P2       | Medium | no         | Pending               |
+| 18  | [Statistics entry-point validation](18-statistics-validation.md) | P0       | High   | **yes**    | Implemented           |
+| 19  | [Deflake existing test suite](19-deflake-existing-tests.md)      | P1       | High   | no         | Pending               |
 
 ## Suggested order
 
 1. **01** first — it installs the quality gates every later spec is verified against.
-   *(Implemented; see the spec for two deliberate deviations from the original draft:
+   _(Implemented; see the spec for two deliberate deviations from the original draft:
    pedantic/nursery lints stay opt-in — split out as Spec 17 — and cargo-crap uses a
    regression gate against a committed baseline rather than an absolute threshold, since
-   9 functions already exceed it today.)*
+   9 functions already exceed it today.)_
 2. **04 → 05** (seeding, then correct samplers) — reproducibility unblocks deflaked tests
-   used by every other spec. *(Both implemented. 04 used `rand_chacha::ChaCha8Rng`
+   used by every other spec. _(Both implemented. 04 used `rand_chacha::ChaCha8Rng`
    directly instead of `rand::rngs::StdRng` — the latter is explicitly documented as
    non-portable in this `rand` version, which would have broken the determinism
    guarantee. Retrofitting every existing statistical test to a fixed seed was split out
@@ -45,9 +45,9 @@ a spec is closed only when every acceptance test passes and `just dev` is green.
    building the seeding infrastructure. 05 found `rand_distr`'s `Gamma`/`Poisson`
    constructors stricter than this crate's committed degenerate-case behavior
    (`scale`/`lambda` of `0`), handled via special-casing before ever calling
-   `rand_distr`; measured a 65.5% speedup for normal sampling.)*
+   `rand_distr`; measured a 65.5% speedup for normal sampling.)_
 3. **02, 03, 06, 18** — the breaking API changes, batched into one 0.3.0 release.
-   *(All four implemented. 02's statistics-entry-point-validation half was split out to
+   _(All four implemented. 02's statistics-entry-point-validation half was split out to
    18 — see 02's spec for why: a comparably large, independently-shippable ripple through
    a different module. 06 kept `evaluate`/`evaluate_arithmetic`/`evaluate_bool` as three
    separate `Result`-returning dispatchers, one total per value domain, rather than one
@@ -56,7 +56,7 @@ a spec is closed only when every acceptance test passes and `just dev` is green.
    at construction time for `LazyStats`/`AdaptiveLazyStats` (sample count fixed once,
    reused by every accessor) and at call time everywhere else (sample
    count/quantile/confidence/bandwidth are genuine per-call parameters) — see 18's spec
-   for the full per-method breakdown.)*
+   for the full per-method breakdown.)_
 4. **07 → 08** — optimizer correctness before optimizer effectiveness.
 5. **09, 10, 11, 14, 15, 17, 19** in any order.
 6. **12, 13, 16** — feature/polish tail.

--- a/src/computation.rs
+++ b/src/computation.rs
@@ -1,3 +1,4 @@
+use crate::error::UncertainError;
 use crate::operations::{Arithmetic, arithmetic::BinaryOperation};
 use crate::traits::Shareable;
 use std::collections::HashMap;
@@ -182,68 +183,72 @@ where
     /// This is the core evaluation method that respects memoization to ensure
     /// shared variables produce consistent samples within a single evaluation.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// - Panics if called on a `BinaryOp` variant. Use `evaluate_arithmetic` instead for binary operations.
-    /// - Panics if called on a `Conditional` variant. Use `evaluate_conditional` instead for conditional operations.
-    pub fn evaluate(&self, context: &mut SampleContext) -> T {
+    /// Returns `UncertainError::UnsupportedNode` if called on a `BinaryOp` variant (use
+    /// `evaluate_arithmetic` instead) or a `Conditional` variant (use `evaluate_arithmetic`,
+    /// which handles conditionals, or `evaluate_bool` for boolean graphs).
+    pub fn evaluate(&self, context: &mut SampleContext) -> Result<T, UncertainError> {
         match self {
             ComputationNode::Leaf { id, sample } => {
                 // Check if we already have a memoized value for this node
                 if let Some(cached) = context.get_value::<T>(id) {
-                    cached
+                    Ok(cached)
                 } else {
                     // Generate new sample and memoize it
                     let value = sample();
                     context.set_value(*id, value.clone());
-                    value
+                    Ok(value)
                 }
             }
 
             ComputationNode::UnaryOp { operand, operation } => {
-                let operand_val = operand.evaluate(context);
-                match operation {
+                let operand_val = operand.evaluate(context)?;
+                Ok(match operation {
                     UnaryOperation::Map(func) => func(operand_val),
                     UnaryOperation::Filter(_) => {
                         // Filter requires special handling with rejection sampling
                         // This is a simplified implementation
                         operand_val
                     }
-                }
+                })
             }
 
             // These variants require special handling based on type constraints
-            ComputationNode::BinaryOp { .. } => {
-                panic!(
-                    "BinaryOp evaluation requires arithmetic trait bounds. Use evaluate_arithmetic instead."
-                )
-            }
+            ComputationNode::BinaryOp { .. } => Err(UncertainError::unsupported_node(
+                "Leaf or UnaryOp",
+                "BinaryOp",
+            )),
 
-            ComputationNode::Conditional { .. } => {
-                panic!(
-                    "Conditional evaluation requires specific handling. Use evaluate_conditional instead."
-                )
-            }
+            ComputationNode::Conditional { .. } => Err(UncertainError::unsupported_node(
+                "Leaf or UnaryOp",
+                "Conditional",
+            )),
         }
     }
 
     /// Evaluates arithmetic operations with proper trait bounds
     ///
-    /// # Panics
+    /// Also handles `Conditional` nodes: the condition is evaluated via `evaluate_bool`
+    /// and the taken branch is evaluated arithmetically, so this is a total dispatcher
+    /// over every `ComputationNode<T>` variant for arithmetic `T`.
     ///
-    /// Panics if called on a `Conditional` variant with a boolean condition, as this is not supported in arithmetic context.
-    pub fn evaluate_arithmetic(&self, context: &mut SampleContext) -> T
+    /// # Errors
+    ///
+    /// Returns `UncertainError::UnsupportedNode` if evaluating a `Conditional`'s boolean
+    /// condition encounters an unsupported node (e.g. a boolean `BinaryOp`).
+    pub fn evaluate_arithmetic(&self, context: &mut SampleContext) -> Result<T, UncertainError>
     where
         T: Arithmetic,
     {
         match self {
             ComputationNode::Leaf { id, sample } => {
                 if let Some(cached) = context.get_value::<T>(id) {
-                    cached
+                    Ok(cached)
                 } else {
                     let value = sample();
                     context.set_value(*id, value.clone());
-                    value
+                    Ok(value)
                 }
             }
 
@@ -252,27 +257,29 @@ where
                 right,
                 operation,
             } => {
-                let left_val = left.evaluate_arithmetic(context);
-                let right_val = right.evaluate_arithmetic(context);
-                operation.apply(left_val, right_val)
+                let left_val = left.evaluate_arithmetic(context)?;
+                let right_val = right.evaluate_arithmetic(context)?;
+                Ok(operation.apply(left_val, right_val))
             }
 
             ComputationNode::UnaryOp { operand, operation } => {
-                let operand_val = operand.evaluate_arithmetic(context);
-                match operation {
+                let operand_val = operand.evaluate_arithmetic(context)?;
+                Ok(match operation {
                     UnaryOperation::Map(func) => func(operand_val),
                     UnaryOperation::Filter(_) => operand_val,
-                }
+                })
             }
 
             ComputationNode::Conditional {
-                condition: _,
-                if_true: _,
-                if_false: _,
+                condition,
+                if_true,
+                if_false,
             } => {
-                panic!(
-                    "Conditional evaluation with bool condition not supported in arithmetic context"
-                )
+                if condition.evaluate_bool(context)? {
+                    if_true.evaluate_arithmetic(context)
+                } else {
+                    if_false.evaluate_arithmetic(context)
+                }
             }
         }
     }
@@ -281,13 +288,21 @@ where
     ///
     /// This creates a fresh context for evaluation, useful when you want
     /// independent samples without memoization effects.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the graph contains a node that isn't evaluable in the arithmetic domain.
+    /// This can't happen for graphs built via the public `Uncertain<T>` combinator API;
+    /// it would only occur from misuse of the low-level `ComputationNode` constructors
+    /// (e.g. directly constructing a boolean `BinaryOp`, which has no defined operation).
     #[must_use]
     pub fn evaluate_fresh(&self) -> T
     where
         T: Arithmetic,
     {
         let mut context = SampleContext::new();
-        self.evaluate_conditional_with_arithmetic(&mut context)
+        self.evaluate_arithmetic(&mut context)
+            .expect("graphs built via the public Uncertain<T> API are always well-formed")
     }
 
     /// Creates a new leaf node
@@ -457,70 +472,44 @@ where
 impl ComputationNode<bool> {
     /// Evaluates boolean computation nodes
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if called on a `BinaryOp` variant as boolean binary operations are not implemented.
-    pub fn evaluate_bool(&self, context: &mut SampleContext) -> bool {
+    /// Returns `UncertainError::UnsupportedNode` if called on a `BinaryOp` variant, since
+    /// no boolean `BinaryOperation` is defined (`BinaryOperation` only covers arithmetic
+    /// operations, and `bool` doesn't implement `Arithmetic`).
+    pub fn evaluate_bool(&self, context: &mut SampleContext) -> Result<bool, UncertainError> {
         match self {
             ComputationNode::Leaf { id, sample } => {
                 if let Some(cached) = context.get_value::<bool>(id) {
-                    cached
+                    Ok(cached)
                 } else {
                     let value = sample();
                     context.set_value(*id, value);
-                    value
+                    Ok(value)
                 }
             }
             ComputationNode::UnaryOp { operand, operation } => {
-                let operand_val = operand.evaluate_bool(context);
-                match operation {
+                let operand_val = operand.evaluate_bool(context)?;
+                Ok(match operation {
                     UnaryOperation::Map(func) => func(operand_val),
                     UnaryOperation::Filter(_) => operand_val,
-                }
+                })
             }
-            ComputationNode::BinaryOp { .. } => {
-                panic!("Boolean binary operations not implemented")
-            }
+            ComputationNode::BinaryOp { .. } => Err(UncertainError::unsupported_node(
+                "Leaf, UnaryOp, or Conditional",
+                "BinaryOp",
+            )),
             ComputationNode::Conditional {
                 condition,
                 if_true,
                 if_false,
             } => {
-                let condition_val = condition.evaluate_bool(context);
-                if condition_val {
+                if condition.evaluate_bool(context)? {
                     if_true.evaluate_bool(context)
                 } else {
                     if_false.evaluate_bool(context)
                 }
             }
-        }
-    }
-}
-
-// Add a specialized method for evaluating conditionals with arithmetic return types
-impl<T> ComputationNode<T>
-where
-    T: Shareable,
-{
-    /// Evaluates conditional nodes where condition is bool and branches return T
-    pub fn evaluate_conditional_with_arithmetic(&self, context: &mut SampleContext) -> T
-    where
-        T: Arithmetic,
-    {
-        match self {
-            ComputationNode::Conditional {
-                condition,
-                if_true,
-                if_false,
-            } => {
-                let condition_val = condition.evaluate_bool(context);
-                if condition_val {
-                    if_true.evaluate_arithmetic(context)
-                } else {
-                    if_false.evaluate_arithmetic(context)
-                }
-            }
-            _ => self.evaluate_arithmetic(context),
         }
     }
 }
@@ -1307,11 +1296,6 @@ impl GraphProfiler {
     }
 
     /// Get profiling statistics
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal state is corrupted and the times vector is empty
-    /// when it shouldn't be (this should never happen in normal usage).
     #[must_use]
     pub fn get_stats(&self, name: &str) -> Option<ProfileStats> {
         let times = self.execution_times.get(name)?;
@@ -1326,12 +1310,8 @@ impl GraphProfiler {
         let mut sorted_times = times.clone();
         sorted_times.sort();
         let median = sorted_times[count / 2];
-        let min = *sorted_times
-            .first()
-            .expect("Times vector should not be empty");
-        let max = *sorted_times
-            .last()
-            .expect("Times vector should not be empty");
+        let min = sorted_times[0];
+        let max = sorted_times[count - 1];
 
         Some(ProfileStats {
             count,
@@ -1428,8 +1408,8 @@ mod tests {
         };
 
         // Evaluate twice with the same context
-        let val1 = leaf.evaluate(&mut context);
-        let val2 = leaf.evaluate(&mut context);
+        let val1 = leaf.evaluate(&mut context).unwrap();
+        let val2 = leaf.evaluate(&mut context).unwrap();
 
         // Should get the same value due to memoization
         assert_eq!(val1, val2);
@@ -1539,51 +1519,59 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "BinaryOp evaluation requires arithmetic trait bounds")]
-    fn test_evaluate_panic_on_binary_op() {
+    fn test_evaluate_err_on_binary_op() {
         let left = ComputationNode::leaf(|| 1.0);
         let right = ComputationNode::leaf(|| 2.0);
         let binary_op = ComputationNode::binary_op(left, right, BinaryOperation::Add);
 
         let mut context = SampleContext::new();
-        binary_op.evaluate(&mut context);
+        let err = binary_op.evaluate(&mut context).unwrap_err();
+        assert_eq!(
+            err,
+            UncertainError::unsupported_node("Leaf or UnaryOp", "BinaryOp")
+        );
     }
 
     #[test]
-    #[should_panic(expected = "Conditional evaluation requires specific handling")]
-    fn test_evaluate_panic_on_conditional() {
+    fn test_evaluate_err_on_conditional() {
         let condition = ComputationNode::leaf(|| true);
         let if_true = ComputationNode::leaf(|| 10.0);
         let if_false = ComputationNode::leaf(|| 20.0);
         let conditional = ComputationNode::conditional(condition, if_true, if_false);
 
         let mut context = SampleContext::new();
-        conditional.evaluate(&mut context);
+        let err = conditional.evaluate(&mut context).unwrap_err();
+        assert_eq!(
+            err,
+            UncertainError::unsupported_node("Leaf or UnaryOp", "Conditional")
+        );
     }
 
     #[test]
-    #[should_panic(
-        expected = "Conditional evaluation with bool condition not supported in arithmetic context"
-    )]
-    fn test_evaluate_arithmetic_panic_on_conditional() {
+    #[allow(clippy::float_cmp)]
+    fn test_evaluate_arithmetic_handles_conditional() {
         let condition = ComputationNode::leaf(|| true);
         let if_true = ComputationNode::leaf(|| 10.0);
         let if_false = ComputationNode::leaf(|| 20.0);
         let conditional = ComputationNode::conditional(condition, if_true, if_false);
 
         let mut context = SampleContext::new();
-        conditional.evaluate_arithmetic(&mut context);
+        let result = conditional.evaluate_arithmetic(&mut context).unwrap();
+        assert_eq!(result, 10.0);
     }
 
     #[test]
-    #[should_panic(expected = "Boolean binary operations not implemented")]
-    fn test_evaluate_bool_panic_on_binary_op() {
+    fn test_evaluate_bool_err_on_binary_op() {
         let left = ComputationNode::leaf(|| true);
         let right = ComputationNode::leaf(|| false);
         let binary_op = ComputationNode::binary_op(left, right, BinaryOperation::Add);
 
         let mut context = SampleContext::new();
-        binary_op.evaluate_bool(&mut context);
+        let err = binary_op.evaluate_bool(&mut context).unwrap_err();
+        assert_eq!(
+            err,
+            UncertainError::unsupported_node("Leaf, UnaryOp, or Conditional", "BinaryOp")
+        );
     }
 
     #[test]
@@ -1606,7 +1594,32 @@ mod tests {
         };
 
         let mut context = SampleContext::new();
-        let result = filtered.evaluate(&mut context);
+        let result = filtered.evaluate(&mut context).unwrap();
+        assert_eq!(result, 42.0); // Filter currently just passes through
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_evaluate_unary_map_operation() {
+        let operand = ComputationNode::leaf(|| 5.0);
+        let mapped = ComputationNode::map(operand, |x| x * 2.0);
+
+        let mut context = SampleContext::new();
+        let result = mapped.evaluate(&mut context).unwrap();
+        assert_eq!(result, 10.0);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_evaluate_arithmetic_unary_filter_operation() {
+        let operand = ComputationNode::leaf(|| 42.0);
+        let filtered = ComputationNode::UnaryOp {
+            operand: Box::new(operand),
+            operation: UnaryOperation::Filter(Arc::new(|x: &f64| *x > 0.0)),
+        };
+
+        let mut context = SampleContext::new();
+        let result = filtered.evaluate_arithmetic(&mut context).unwrap();
         assert_eq!(result, 42.0); // Filter currently just passes through
     }
 
@@ -1886,7 +1899,7 @@ mod tests {
         let conditional = ComputationNode::conditional(condition, if_true, if_false);
 
         let mut context = SampleContext::new();
-        let result = conditional.evaluate_bool(&mut context);
+        let result = conditional.evaluate_bool(&mut context).unwrap();
         assert!(result);
     }
 
@@ -1896,8 +1909,47 @@ mod tests {
         let mapped = ComputationNode::map(operand, |x| !x);
 
         let mut context = SampleContext::new();
-        let result = mapped.evaluate_bool(&mut context);
+        let result = mapped.evaluate_bool(&mut context).unwrap();
         assert!(!result);
+    }
+
+    #[test]
+    fn test_bool_conditional_evaluation_false_branch() {
+        let condition = ComputationNode::leaf(|| false);
+        let if_true = ComputationNode::leaf(|| true);
+        let if_false = ComputationNode::leaf(|| false);
+        let conditional = ComputationNode::conditional(condition, if_true, if_false);
+
+        let mut context = SampleContext::new();
+        let result = conditional.evaluate_bool(&mut context).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_bool_leaf_memoization() {
+        let mut context = SampleContext::new();
+        let leaf_id = uuid::Uuid::new_v4();
+        let leaf = ComputationNode::Leaf {
+            id: leaf_id,
+            sample: Arc::new(rand::random::<bool>),
+        };
+
+        let val1 = leaf.evaluate_bool(&mut context).unwrap();
+        let val2 = leaf.evaluate_bool(&mut context).unwrap();
+        assert_eq!(val1, val2);
+    }
+
+    #[test]
+    fn test_bool_unary_filter_operation() {
+        let operand = ComputationNode::leaf(|| true);
+        let filtered = ComputationNode::UnaryOp {
+            operand: Box::new(operand),
+            operation: UnaryOperation::Filter(Arc::new(|x: &bool| *x)),
+        };
+
+        let mut context = SampleContext::new();
+        let result = filtered.evaluate_bool(&mut context).unwrap();
+        assert!(result); // Filter currently just passes through
     }
 
     #[test]
@@ -1952,18 +2004,18 @@ mod tests {
 
     #[test]
     #[allow(clippy::float_cmp)]
-    fn test_evaluate_conditional_with_arithmetic() {
+    fn test_evaluate_arithmetic_total_dispatch() {
         let condition = ComputationNode::leaf(|| true);
         let if_true = ComputationNode::leaf(|| 42.0);
         let if_false = ComputationNode::leaf(|| 24.0);
         let conditional = ComputationNode::conditional(condition, if_true, if_false);
 
         let mut context = SampleContext::new();
-        let result = conditional.evaluate_conditional_with_arithmetic(&mut context);
+        let result = conditional.evaluate_arithmetic(&mut context).unwrap();
         assert_eq!(result, 42.0);
 
         let leaf = ComputationNode::leaf(|| 99.0);
-        let result = leaf.evaluate_conditional_with_arithmetic(&mut context);
+        let result = leaf.evaluate_arithmetic(&mut context).unwrap();
         assert_eq!(result, 99.0);
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,17 @@ pub enum UncertainError {
         /// The invalid bandwidth value
         value: f64,
     },
+
+    /// Error when a computation graph node can't be evaluated in the requested domain
+    /// (e.g. a `BinaryOp` node evaluated where only `Leaf`/`UnaryOp` are supported, or a
+    /// boolean `BinaryOp` node, for which no `BinaryOperation` is defined).
+    #[error("Unsupported node: expected {expected}, found {found}")]
+    UnsupportedNode {
+        /// What the evaluation method can handle
+        expected: &'static str,
+        /// The node kind actually encountered
+        found: &'static str,
+    },
 }
 
 /// A specialized `Result` type for uncertain operations.
@@ -215,6 +226,21 @@ impl UncertainError {
     pub fn invalid_bandwidth(value: f64) -> Self {
         Self::InvalidBandwidth { value }
     }
+
+    /// Create an error for a computation graph node that can't be evaluated in the
+    /// requested domain.
+    ///
+    /// # Example
+    /// ```
+    /// use uncertain_rs::error::UncertainError;
+    ///
+    /// let error = UncertainError::unsupported_node("Leaf or UnaryOp", "BinaryOp");
+    /// assert!(error.to_string().contains("BinaryOp"));
+    /// ```
+    #[must_use]
+    pub fn unsupported_node(expected: &'static str, found: &'static str) -> Self {
+        Self::UnsupportedNode { expected, found }
+    }
 }
 
 #[cfg(test)]
@@ -301,6 +327,13 @@ mod tests {
         let error = UncertainError::invalid_bandwidth(-0.1);
         assert!(error.to_string().contains("-0.1"));
         assert!(error.to_string().contains("positive"));
+    }
+
+    #[test]
+    fn test_unsupported_node_error() {
+        let error = UncertainError::unsupported_node("Leaf or UnaryOp", "BinaryOp");
+        assert!(error.to_string().contains("Leaf or UnaryOp"));
+        assert!(error.to_string().contains("BinaryOp"));
     }
 
     #[test]

--- a/src/uncertain.rs
+++ b/src/uncertain.rs
@@ -77,7 +77,9 @@ where
         let node_clone = node.clone();
         let sample_fn = Arc::new(move || {
             let mut context = SampleContext::new();
-            node_clone.evaluate_conditional_with_arithmetic(&mut context)
+            node_clone
+                .evaluate_arithmetic(&mut context)
+                .expect("graphs built via the public Uncertain<T> API are always well-formed")
         });
         let id = uuid::Uuid::new_v4();
 


### PR DESCRIPTION
## Summary
- `ComputationNode::evaluate`, `evaluate_arithmetic`, and `evaluate_bool` now return `Result<_, UncertainError>` instead of panicking on unsupported node/domain combinations. New error variant `UncertainError::UnsupportedNode { expected, found }`.
- `evaluate_arithmetic` absorbs the former `evaluate_conditional_with_arithmetic` (now deleted) and is the total dispatcher for the arithmetic domain, including `Conditional` nodes.
- `evaluate_fresh` keeps its infallible `-> T` signature (used by ~20 existing callers, mostly tests) via an internal `.expect()` justified by the invariant that graphs built through the public `Uncertain<T>` API are always well-formed.
- `GraphProfiler::get_stats`'s two now-unreachable `.expect()` calls replaced with direct indexing.
- All `#[should_panic]` evaluation tests replaced with `Result`/error-variant assertions; added tests closing coverage gaps the rewrite exposed.
- See `specs/06-total-graph-evaluation.md` for the full spec and an "Implementation notes" section documenting why this keeps three separate domain-scoped dispatchers (`evaluate`/`evaluate_arithmetic`/`evaluate_bool`) rather than one universal dispatcher — each is total over a different variant set dictated by `T`'s trait bounds.
- `crap_baseline.json` regenerated: the three rewritten methods show a higher CRAP score (CC +1 to +5) from the added `Result` plumbing, but all reached 100% line coverage in this change, so the increase is pure complexity, not a coverage gap.
- This branch was cut before specs 05/18 merged; rebased cleanly onto current `main` (conflicts only in `specs/README.md`/`MIGRATION_GUIDE.md`/`CHANGELOG.md`, resolved by combining both specs' notes).

## Test plan
- [x] `just dev` green (fmt, clippy `-D warnings`, tests default + `parallel`, doc tests, audit, deny, crap regression gate) — reconfirmed after rebase
- [x] Full test suite + doctests pass with `--all-features` and `--features parallel`
- [x] `cargo bench` sanity check on `computation_graphs` — all three benchmarks within noise
- [x] `CHANGELOG.md`/`MIGRATION_GUIDE.md`/`specs/README.md` updated

https://claude.ai/code/session_01Xw68NoMZnNRLkxjK6Razu7